### PR TITLE
Fix gcc issues

### DIFF
--- a/Code/Entity.cpp
+++ b/Code/Entity.cpp
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include "Entity.h"
 #include "Collision.h"
 #include "Graphics.h"

--- a/Code/Scene.h
+++ b/Code/Scene.h
@@ -65,8 +65,6 @@ namespace Monocle
 		virtual void ReceiveNote(const std::string &note, Entity *fromEntity);
 
 	private:
-
-		friend class Entity;
 		void RelayNoteTo(const std::string &tag, const std::string &note, Entity *fromEntity);
 
 	private:


### PR DESCRIPTION
Your last commit made gcc sad. ;)
The missing cstdio include for printf made it impossible to compile, the double friendship of Entity and Scene cause a warning.
