### PR TITLE
Better Mac OS citizenship and platform-default content paths

### DIFF
--- a/Code/Assets.cpp
+++ b/Code/Assets.cpp
@@ -2,6 +2,7 @@
 #include "TextureAsset.h"
 #include <stdio.h> // for NULL
 #include "Debug.h"
+#include "Platform.h"
 
 namespace Monocle
 {
@@ -14,6 +15,7 @@ namespace Monocle
 
 	void Assets::Init()
 	{
+        SetContentPath(Platform::GetDefaultContentPath());
 	}
 
 	TextureAsset *Assets::RequestTexture(const std::string &filename, FilterType filter, bool repeatX, bool repeatY)

--- a/Code/Cocoa/CocoaEvents.mm
+++ b/Code/Cocoa/CocoaEvents.mm
@@ -74,16 +74,16 @@ CreateApplicationMenus(void)
 	title = [@"About " stringByAppendingString:appName];
 	[appleMenu addItemWithTitle:title action:@selector(orderFrontStandardAboutPanel:) keyEquivalent:@""];
 
-	[appleMenu addItem:[NSMenuItem separatorItem]];
+//	[appleMenu addItem:[NSMenuItem separatorItem]];
 
-	[appleMenu addItemWithTitle:@"Preferences" action:nil keyEquivalent:@""];
+//	[appleMenu addItemWithTitle:@"Preferences" action:nil keyEquivalent:@","];
 
-	[appleMenu addItem:[NSMenuItem separatorItem]];
+//	[appleMenu addItem:[NSMenuItem separatorItem]];
 
 	title = [@"Hide " stringByAppendingString:appName];
-	[appleMenu addItemWithTitle:title action:@selector(hide:) keyEquivalent:@/*"h"*/""];
+	[appleMenu addItemWithTitle:title action:@selector(hide:) keyEquivalent:@"h"];
 
-	menuItem = (NSMenuItem *)[appleMenu addItemWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@/*"h"*/""];
+	menuItem = (NSMenuItem *)[appleMenu addItemWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@"h"];
 	[menuItem setKeyEquivalentModifierMask:(NSAlternateKeyMask|NSCommandKeyMask)];
 
 	[appleMenu addItemWithTitle:@"Show All" action:@selector(unhideAllApplications:) keyEquivalent:@""];
@@ -91,7 +91,7 @@ CreateApplicationMenus(void)
 	[appleMenu addItem:[NSMenuItem separatorItem]];
 
 	title = [@"Quit " stringByAppendingString:appName];
-	[appleMenu addItemWithTitle:title action:@selector(terminate:) keyEquivalent:@/*"q"*/""];
+	[appleMenu addItemWithTitle:title action:@selector(terminate:) keyEquivalent:@"q"];
 
 	/* Put menu into the menubar */
 	menuItem = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
@@ -104,23 +104,23 @@ CreateApplicationMenus(void)
 	[appleMenu release];
 
 
-	/* Create the window menu */
-	windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
-
-	/* "Minimize" item */
-	menuItem = [[NSMenuItem alloc] initWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@/*"m"*/""];
-	[windowMenu addItem:menuItem];
-	[menuItem release];
-
-	/* Put menu into the menubar */
-	menuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
-	[menuItem setSubmenu:windowMenu];
-	[[NSApp mainMenu] addItem:menuItem];
-	[menuItem release];
-
-	/* Tell the application object that this is now the window menu */
-	[NSApp setWindowsMenu:windowMenu];
-	[windowMenu release];
+//	/* Create the window menu */
+//	windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
+//
+//	/* "Minimize" item */
+//	menuItem = [[NSMenuItem alloc] initWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@/*"m"*/""];
+//	[windowMenu addItem:menuItem];
+//	[menuItem release];
+//
+//	/* Put menu into the menubar */
+//	menuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
+//	[menuItem setSubmenu:windowMenu];
+//	[[NSApp mainMenu] addItem:menuItem];
+//	[menuItem release];
+//
+//	/* Tell the application object that this is now the window menu */
+//	[NSApp setWindowsMenu:windowMenu];
+//	[windowMenu release];
 }
 
 void

--- a/Code/Cocoa/CocoaPlatform.h
+++ b/Code/Cocoa/CocoaPlatform.h
@@ -20,6 +20,8 @@ namespace Monocle
 
 		NSWindow* window;
 		WindowData* windowData;
+        
+        std::string bundleResourcesPath;
 	};
 }
 

--- a/Code/Cocoa/CocoaPlatform.mm
+++ b/Code/Cocoa/CocoaPlatform.mm
@@ -77,7 +77,7 @@ static WindowData* AttachWindowListener(NSWindow* window)
 	WindowData* data = (WindowData*) calloc(1, sizeof(WindowData));
 	if (!data) {
 		Debug::Log("Error allocating window data");
-		return false;
+		return NULL;
 	}
 	data->created = true;
 	data->nswindow = window;
@@ -104,6 +104,8 @@ namespace Monocle
 	{
 		//  Init event loop
 		Cocoa_RegisterApp();
+        
+        this->bundleResourcesPath = [[[NSBundle mainBundle] resourcePath] fileSystemRepresentation];
 
 		//  Create window
 		window = CreateWindowCocoa(w, h);
@@ -160,7 +162,7 @@ namespace Monocle
 		instance->width  = (int)rect.size.width;
 		instance->height = (int)rect.size.height;
 	}
-
+    
 	void Platform::Update()
 	{
 		Cocoa_PumpEvents();
@@ -231,4 +233,8 @@ namespace Monocle
 	{
 		return [NSApp isActive];
 	}
+
+    std::string Platform::GetDefaultContentPath() {
+        return CocoaPlatform::instance->bundleResourcesPath+"/Content/";
+    }
 }

--- a/Code/Cocoa/CocoaWindowListener.mm
+++ b/Code/Cocoa/CocoaWindowListener.mm
@@ -91,8 +91,12 @@ static __inline__ void ConvertNSRect(NSRect *r)
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
-	int buttonNumber = [theEvent buttonNumber];
-	CocoaPlatform::platform->SetMouseButton(buttonNumber, true);
+	NSInteger buttonNumber = [theEvent buttonNumber];
+    if([theEvent modifierFlags] & NSControlKeyMask)
+    {
+        buttonNumber = 1;
+    }
+	CocoaPlatform::platform->SetMouseButton((int)buttonNumber, true);
 }
 
 - (void)rightMouseDown:(NSEvent *)theEvent
@@ -107,8 +111,12 @@ static __inline__ void ConvertNSRect(NSRect *r)
 
 - (void)mouseUp:(NSEvent *)theEvent
 {
-	int buttonNumber = [theEvent buttonNumber];
-	CocoaPlatform::platform->SetMouseButton(buttonNumber, false);
+	NSInteger buttonNumber = [theEvent buttonNumber];
+    if([theEvent modifierFlags] & NSControlKeyMask)
+    {
+        buttonNumber = 1;
+    }
+	CocoaPlatform::platform->SetMouseButton((int)buttonNumber, false);
 }
 
 - (void)rightMouseUp:(NSEvent *)theEvent

--- a/Code/Cocoa/CocoaWindowListener.mm
+++ b/Code/Cocoa/CocoaWindowListener.mm
@@ -178,6 +178,10 @@ static __inline__ void ConvertNSRect(NSRect *r)
 {
 }
 
+-(void) handleTouches:(cocoaTouchType)type withEvent:(NSEvent*) event {
+    
+}
+
 @end
 
 void

--- a/Code/Linux/LinuxPlatform.cpp
+++ b/Code/Linux/LinuxPlatform.cpp
@@ -383,6 +383,11 @@ namespace Monocle
 			instance->keys[instance->localKeymap[key]] = on;
 		}
 	}
+
+  const std::string Platform::GetDefaultContentPath() {
+    return "../../Content/";
+  }
+
 }
 
 #endif

--- a/Code/Platform.h
+++ b/Code/Platform.h
@@ -174,6 +174,8 @@ namespace Monocle
 		static bool IsActive();
 
 		void WindowSizeChanged(int w, int h);
+        
+        static std::string GetDefaultContentPath();
 
 	private:
 		static Platform *instance;

--- a/Code/Tests/FTE/FTE.cpp
+++ b/Code/Tests/FTE/FTE.cpp
@@ -36,7 +36,7 @@ namespace FTE
 		Scene::Begin();
 
 		// set the base content path (used by everything)
-		Assets::SetContentPath("../../Content/FTE/");
+		Assets::SetContentPath(Assets::GetContentPath()+"FTE/");
 
 		Graphics::SetBackgroundColor(Color::blue*0.1f + Color::black*0.9f);
 

--- a/Code/Tests/Flash/Flash.cpp
+++ b/Code/Tests/Flash/Flash.cpp
@@ -50,7 +50,7 @@ namespace Flash
 		if (texture != NULL)
 		{
 			Entity *entity = new Entity();
-			Sprite *sprite = new Sprite("../../Content/Flash/" + textureSheet.name + "/" + name + ".png");
+			Sprite *sprite = new Sprite(Assets::GetContentPath() + textureSheet.name + "/" + name + ".png");
 			sprite->position = (texture->registrationPoint * -1) + Vector2(sprite->width, sprite->height)*0.5f;
 			//sprite->position = texture->registrationPoint * -1;
 			entity->SetGraphic(sprite);
@@ -232,6 +232,9 @@ namespace Flash
 		Scene::Begin();
 
 		Graphics::SetBackgroundColor(Color::black);
+        
+        Assets::SetContentPath(Assets::GetContentPath()+"Flash/");
+        const std::string cp = Assets::GetContentPath();
 
 		editPart = NULL;
 		selectedPartIndex = 0;
@@ -241,10 +244,10 @@ namespace Flash
 		isEditing = false;
 		
 #ifdef ANIM_MONOCLE_LOGO
-		LoadAnimation("../../Content/Flash/animations.xml");
-		LoadTextureSheet("../../Content/Flash/sheets.xml");
+		LoadAnimation(cp+"animations.xml");
+		LoadTextureSheet(cp+"sheets.xml");
 #else
-		LoadAnimation("../../Content/Flash/test.xml");
+		LoadAnimation(cp+"test.xml");
 #endif
 
 		eAnimation = new Entity();

--- a/Code/Tests/Jumper/Jumper.cpp
+++ b/Code/Tests/Jumper/Jumper.cpp
@@ -132,7 +132,7 @@ namespace Jumper
 		Debug::Log("Jumper::GameScene::Begin()!");
 		Scene::Begin();
 
-		Assets::SetContentPath("../../Content/Jumper/");
+		Assets::SetContentPath(Assets::GetContentPath()+"Jumper/");
 
 		Input::DefineMaskKey("jump", KEY_UP);
 		Input::DefineMaskKey("jump", KEY_Z);

--- a/Code/Tests/Ogmo/Ogmo.cpp
+++ b/Code/Tests/Ogmo/Ogmo.cpp
@@ -321,7 +321,7 @@ namespace Ogmo
 		Graphics::SetCameraPosition(Vector2(80, 60));
 
 		//assets
-		Assets::SetContentPath("../../Content/Ogmo/");
+		Assets::SetContentPath(Assets::GetContentPath()+"Ogmo/");
 		atCoin = new Sprite("coin.png", FILTER_NONE, 8, 8);
 		atSpike = new Sprite("spike.png", FILTER_NONE, 8, 8);
 

--- a/Code/Windows/WindowsPlatform.cpp
+++ b/Code/Windows/WindowsPlatform.cpp
@@ -730,6 +730,10 @@ namespace Monocle
 	{
 		return WindowsPlatform::instance->active;
 	}
+
+  const std::string Platform::GetDefaultContentPath() {
+      return "../../Content/";
+  }
 }
 
 #endif

--- a/Project/Xcode4/MonocleTest/MonocleTest.xcodeproj/project.pbxproj
+++ b/Project/Xcode4/MonocleTest/MonocleTest.xcodeproj/project.pbxproj
@@ -67,6 +67,9 @@
 		37FB69B613317693008963C1 /* Vector3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697E13317693008963C1 /* Vector3.cpp */; };
 		37FB69B813319030008963C1 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FB69B713319030008963C1 /* OpenGL.framework */; };
 		6657ED15133F9E8F00ACA1E2 /* FTE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6657ED13133F9E8F00ACA1E2 /* FTE.cpp */; };
+		D876F29613456E7500A021D8 /* PathMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D876F29413456E7500A021D8 /* PathMesh.cpp */; };
+		D876F29913456E9900A021D8 /* XMLFileNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D876F29713456E9900A021D8 /* XMLFileNode.cpp */; };
+		D876F2D313456F6400A021D8 /* Content in Resources */ = {isa = PBXBuildFile; fileRef = D876F2D213456F6400A021D8 /* Content */; };
 		D881B50013445142008EF89C /* Node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D881B4FE13445142008EF89C /* Node.cpp */; };
 		F9257DC81338235100A47E00 /* Game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DC61338235100A47E00 /* Game.cpp */; };
 		F9257DCD1338236300A47E00 /* Level.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DCB1338236300A47E00 /* Level.cpp */; };
@@ -194,6 +197,11 @@
 		37FB69B713319030008963C1 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		6657ED13133F9E8F00ACA1E2 /* FTE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FTE.cpp; sourceTree = "<group>"; };
 		6657ED14133F9E8F00ACA1E2 /* FTE.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FTE.h; sourceTree = "<group>"; };
+		D876F29413456E7500A021D8 /* PathMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PathMesh.cpp; path = ../../../Code/LevelEditor/PathMesh.cpp; sourceTree = "<group>"; };
+		D876F29513456E7500A021D8 /* PathMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PathMesh.h; path = ../../../Code/LevelEditor/PathMesh.h; sourceTree = "<group>"; };
+		D876F29713456E9900A021D8 /* XMLFileNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XMLFileNode.cpp; sourceTree = "<group>"; };
+		D876F29813456E9900A021D8 /* XMLFileNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLFileNode.h; sourceTree = "<group>"; };
+		D876F2D213456F6400A021D8 /* Content */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Content; path = ../../../../Content; sourceTree = "<group>"; };
 		D881B4FE13445142008EF89C /* Node.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Node.cpp; path = ../../../Code/LevelEditor/Node.cpp; sourceTree = "<group>"; };
 		D881B4FF13445142008EF89C /* Node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Node.h; path = ../../../Code/LevelEditor/Node.h; sourceTree = "<group>"; };
 		F9257DC61338235100A47E00 /* Game.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Game.cpp; path = ../../../Code/Game.cpp; sourceTree = SOURCE_ROOT; };
@@ -247,6 +255,8 @@
 				37B1929A13359C9D00D2D264 /* tinyxml.h */,
 				37B1929B13359C9D00D2D264 /* tinyxmlerror.cpp */,
 				37B1929C13359C9D00D2D264 /* tinyxmlparser.cpp */,
+				D876F29713456E9900A021D8 /* XMLFileNode.cpp */,
+				D876F29813456E9900A021D8 /* XMLFileNode.h */,
 			);
 			name = XML;
 			path = ../../../Code/XML;
@@ -323,6 +333,7 @@
 		37EA24A0132F986900D216B0 /* MonocleTest */ = {
 			isa = PBXGroup;
 			children = (
+				D876F2D213456F6400A021D8 /* Content */,
 				37EA24A1132F986900D216B0 /* Supporting Files */,
 			);
 			path = MonocleTest;
@@ -540,6 +551,8 @@
 				F9F7D5FD133D3F3C002953B0 /* FringeTileEditor.h */,
 				F9F7D5FE133D3F3C002953B0 /* LevelEditor.cpp */,
 				F9F7D5FF133D3F3C002953B0 /* LevelEditor.h */,
+				D876F29413456E7500A021D8 /* PathMesh.cpp */,
+				D876F29513456E7500A021D8 /* PathMesh.h */,
 			);
 			name = LevelEditor;
 			sourceTree = "<group>";
@@ -604,6 +617,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				37EA24A5132F986900D216B0 /* InfoPlist.strings in Resources */,
+				D876F2D313456F6400A021D8 /* Content in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -682,6 +696,8 @@
 				F9F7D602133D3F3C002953B0 /* LevelEditor.cpp in Sources */,
 				6657ED15133F9E8F00ACA1E2 /* FTE.cpp in Sources */,
 				D881B50013445142008EF89C /* Node.cpp in Sources */,
+				D876F29613456E7500A021D8 /* PathMesh.cpp in Sources */,
+				D876F29913456E9900A021D8 /* XMLFileNode.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Project/Xcode4/MonocleTest/MonocleTest/MonocleTest-Info.plist
+++ b/Project/Xcode4/MonocleTest/MonocleTest/MonocleTest-Info.plist
@@ -22,6 +22,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
The big change: the Mac version now includes the Content/ folder as a resource in Xcode which gets copied into the application bundle. All platforms now have the concept of a "default content path" for Assets, and for the Mac it's MyApp.app/Contents/Resources/Content/. I could go either way on whether it should be /Resources/Content or /Resources, but I didn't want to rock the boat too much. For Windows and Linux, the default path is "../../Content", as before. Demos have all been updated to append their content subpath to the current Assets content path.

Smaller changes: Cmd-Q now quits Monocle games on the Mac (this should probably be toggle-able, but it's such a nice thing for debugging) and ctrl-click simulates right-click (again, maybe worth a toggle, but such an expected feature for Mac people).

Hope you like it!
