### PR TITLE
Initial mouse wheel support for linux platform

### DIFF
--- a/Code/Linux/LinuxPlatform.cpp
+++ b/Code/Linux/LinuxPlatform.cpp
@@ -291,6 +291,7 @@ namespace Monocle
 
     void Platform::Update()
     {
+        mouseWheel = 0; //reset mouse wheel state
         XEvent event;
 
         while (XPending(LinuxPlatform::instance->hDisplay)) { XNextEvent(LinuxPlatform::instance->hDisplay, &event);
@@ -317,6 +318,11 @@ namespace Monocle
                         button = MOUSE_BUTTON_MIDDLE; break;
                     case Button3: // right click
                         button = MOUSE_BUTTON_RIGHT; break;
+                    // TODO check if 120 is the right amount and generalise code
+                    case Button4:
+                        mouseWheel -= 120; break;
+                    case Button5:
+                        mouseWheel += 120; break;
                     }
 
                     Platform::SetMouseButton(button,


### PR DESCRIPTION
Now mouse wheel works under linux. Tested with "TestFTE". I'm not sure if the delta is right: i've choose 120 in accordance to windows platform implementation and microsoft specifications ( http://msdn.microsoft.com/en-us/library/ms645617(v=vs.85).aspx )
