### PR TITLE
Linux platform mouse wheel direction inverted

### DIFF
--- a/Code/Linux/LinuxPlatform.cpp
+++ b/Code/Linux/LinuxPlatform.cpp
@@ -320,9 +320,9 @@ namespace Monocle
                         button = MOUSE_BUTTON_RIGHT; break;
                     // TODO check if 120 is the right amount and generalise code
                     case Button4:
-                        mouseWheel -= 120; break;
-                    case Button5:
                         mouseWheel += 120; break;
+                    case Button5:
+                        mouseWheel -= 120; break;
                     }
 
                     Platform::SetMouseButton(button,


### PR DESCRIPTION
Linux platform mouse wheel direction inverted. Now it should act like windows version.
