### PR TITLE
MacOSX Framework Building and a small fix

### DIFF
--- a/Code/Cocoa/CocoaPlatform.mm
+++ b/Code/Cocoa/CocoaPlatform.mm
@@ -111,6 +111,7 @@ namespace Monocle
             }
         } else {
             this->bundleResourcesPath = [[[NSBundle mainBundle] resourcePath] fileSystemRepresentation];
+            this->bundleResourcesPath = this->bundleResourcesPath + std::string("/Content");
         }
 
 		//  Create window

--- a/Project/Xcode4/MonocleTest/Monocle/Monocle-Info.plist
+++ b/Project/Xcode4/MonocleTest/Monocle/Monocle-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>org.monoclepowered.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>MonoclePowered.org! All rights for looking good in a single-lens reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Project/Xcode4/MonocleTest/Monocle/Monocle-Prefix.pch
+++ b/Project/Xcode4/MonocleTest/Monocle/Monocle-Prefix.pch
@@ -1,0 +1,7 @@
+//
+// Prefix header for all source files of the 'Monocle' target in the 'Monocle' project
+//
+
+#ifdef __OBJC__
+    #import <Cocoa/Cocoa.h>
+#endif

--- a/Project/Xcode4/MonocleTest/Monocle/en.lproj/InfoPlist.strings
+++ b/Project/Xcode4/MonocleTest/Monocle/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/Project/Xcode4/MonocleTest/MonocleTest.xcodeproj/project.pbxproj
+++ b/Project/Xcode4/MonocleTest/MonocleTest.xcodeproj/project.pbxproj
@@ -7,87 +7,108 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		031FEECE1367AFD100B62E27 /* TextureAtlas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEECC1367AFD100B62E27 /* TextureAtlas.cpp */; };
-		031FEED41367B02100B62E27 /* Puppet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED01367B02100B62E27 /* Puppet.cpp */; };
-		031FEED51367B02100B62E27 /* PuppetEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED21367B02100B62E27 /* PuppetEditor.cpp */; };
-		031FEED81367B12000B62E27 /* Audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED71367B12000B62E27 /* Audio.cpp */; };
-		031FEEDB1367B8C600B62E27 /* AudioVis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED91367B8C500B62E27 /* AudioVis.cpp */; };
-		031FEEDE1367BB4B00B62E27 /* VisCache2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEEDC1367BB4A00B62E27 /* VisCache2.cpp */; };
-		031FEEE11367BB7200B62E27 /* fft.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEEDF1367BB7100B62E27 /* fft.cpp */; };
-		031FEEEC1367BF2700B62E27 /* AudioDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEEEA1367BF2600B62E27 /* AudioDeck.cpp */; };
-		035BC67E1368D744002756A4 /* AudioAssetReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 035BC67C1368D743002756A4 /* AudioAssetReader.cpp */; };
-		037066A61369D25F00B7F9C4 /* ChannelStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 037066A51369D25F00B7F9C4 /* ChannelStream.cpp */; };
-		037D6F73136AF225001CFBB9 /* OggDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 037D6F6B136AF225001CFBB9 /* OggDecoder.cpp */; };
-		037D6F74136AF225001CFBB9 /* WaveDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 037D6F71136AF225001CFBB9 /* WaveDecoder.cpp */; };
 		037D6F86136AFB51001CFBB9 /* Vorbis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 037D6F84136AFB51001CFBB9 /* Vorbis.framework */; };
 		037D6FBC136AFE94001CFBB9 /* GLEW.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 037D6FBB136AFE94001CFBB9 /* GLEW.framework */; };
-		037D6FC2136B027F001CFBB9 /* GLEW.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 037D6FBF136B027E001CFBB9 /* GLEW.framework */; };
-		037D6FC3136B027F001CFBB9 /* Vorbis.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 037D6FC0136B027E001CFBB9 /* Vorbis.framework */; };
-		03907B2B135E5E0300D92F21 /* CollisionData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B29135E5E0300D92F21 /* CollisionData.cpp */; };
-		03907B30135E5E9B00D92F21 /* MonocleToolkit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B2E135E5E9B00D92F21 /* MonocleToolkit.cpp */; };
-		03907B37135E5EC400D92F21 /* LevelEditorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B33135E5EC400D92F21 /* LevelEditorTest.cpp */; };
-		03907B3B135E5F0E00D92F21 /* ImageBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B39135E5F0E00D92F21 /* ImageBrowser.cpp */; };
-		03907B3D135E5F3B00D92F21 /* stb_image.c in Sources */ = {isa = PBXBuildFile; fileRef = 03907B3C135E5F3B00D92F21 /* stb_image.c */; };
 		03907B41135E618F00D92F21 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03907B40135E618F00D92F21 /* OpenAL.framework */; };
-		03907B6B135E684700D92F21 /* AudioTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B67135E684700D92F21 /* AudioTest.cpp */; };
-		03907B71135E704D00D92F21 /* AudioDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B6F135E704D00D92F21 /* AudioDecoder.cpp */; };
-		03907B73135E74F500D92F21 /* AudioAsset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B72135E74F500D92F21 /* AudioAsset.cpp */; };
-		03907B81135E81D700D92F21 /* AudioCrypt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B7F135E81D600D92F21 /* AudioCrypt.cpp */; };
-		03A1D876135F297A00831F9E /* Editor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03A1D875135F297A00831F9E /* Editor.cpp */; };
-		3782F004133864AD0042BAE7 /* CocoaKeys.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3782F003133864AD0042BAE7 /* CocoaKeys.mm */; };
-		37AABF3613333E29004E2D56 /* Assets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37AABF3413333E29004E2D56 /* Assets.cpp */; };
-		37AABF381333478A004E2D56 /* Main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37AABF371333478A004E2D56 /* Main.cpp */; };
-		37B192931335995600D2D264 /* CocoaPlatform.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192921335995600D2D264 /* CocoaPlatform.mm */; };
-		37B1929713359BE600D2D264 /* Flash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929513359BE600D2D264 /* Flash.cpp */; };
-		37B1929D13359C9D00D2D264 /* tinyxml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929913359C9D00D2D264 /* tinyxml.cpp */; };
-		37B1929E13359C9D00D2D264 /* tinyxmlerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929B13359C9D00D2D264 /* tinyxmlerror.cpp */; };
-		37B1929F13359C9D00D2D264 /* tinyxmlparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929C13359C9D00D2D264 /* tinyxmlparser.cpp */; };
-		37B192B41335A9C200D2D264 /* CocoaOpenGL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192B31335A9C200D2D264 /* CocoaOpenGL.mm */; };
-		37B192B71335B0E800D2D264 /* CocoaEvents.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192B61335B0E800D2D264 /* CocoaEvents.mm */; };
-		37B192C013361FDA00D2D264 /* CocoaWindowListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192BF13361FDA00D2D264 /* CocoaWindowListener.mm */; };
-		37CAD629133259DD009BC5F3 /* Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CAD627133259DD009BC5F3 /* Sprite.cpp */; };
+		03B6BFB6136C758A00E40253 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37EA249A132F986900D216B0 /* Cocoa.framework */; };
+		03B6BFBC136C758A00E40253 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 03B6BFBA136C758A00E40253 /* InfoPlist.strings */; };
+		03B6C01D136C778A00E40253 /* GLEW.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 037D6FBF136B027E001CFBB9 /* GLEW.framework */; };
+		03B6C01E136C778A00E40253 /* Vorbis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 037D6FC0136B027E001CFBB9 /* Vorbis.framework */; };
+		03B6C020136C77A000E40253 /* GLEW.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 037D6FBF136B027E001CFBB9 /* GLEW.framework */; };
+		03B6C021136C77A000E40253 /* Vorbis.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 037D6FC0136B027E001CFBB9 /* Vorbis.framework */; };
+		03B6C0A0136C77F800E40253 /* XMLFileNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D63813457F3B002953B0 /* XMLFileNode.cpp */; };
+		03B6C0A1136C77F800E40253 /* tinyxml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929913359C9D00D2D264 /* tinyxml.cpp */; };
+		03B6C0A2136C77F800E40253 /* tinyxmlerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929B13359C9D00D2D264 /* tinyxmlerror.cpp */; };
+		03B6C0A3136C77F800E40253 /* tinyxmlparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929C13359C9D00D2D264 /* tinyxmlparser.cpp */; };
+		03B6C0A5136C77F800E40253 /* Asset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691413317693008963C1 /* Asset.cpp */; };
+		03B6C0A6136C77F800E40253 /* Puppet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED01367B02100B62E27 /* Puppet.cpp */; };
+		03B6C0A7136C77F800E40253 /* PuppetEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED21367B02100B62E27 /* PuppetEditor.cpp */; };
+		03B6C0A8136C77F800E40253 /* Assets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37AABF3413333E29004E2D56 /* Assets.cpp */; };
+		03B6C0A9136C77F800E40253 /* Camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9132A12134A0D8C00567EAB /* Camera.cpp */; };
+		03B6C0AA136C77F800E40253 /* Collision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692013317693008963C1 /* Collision.cpp */; };
+		03B6C0AB136C77F800E40253 /* FileNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D63B13457F46002953B0 /* FileNode.cpp */; };
+		03B6C0AC136C77F800E40253 /* Color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692213317693008963C1 /* Color.cpp */; };
+		03B6C0AD136C77F800E40253 /* Debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692613317693008963C1 /* Debug.cpp */; };
+		03B6C0AE136C77F800E40253 /* Editor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03A1D875135F297A00831F9E /* Editor.cpp */; };
+		03B6C0AF136C77F800E40253 /* Entity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692913317693008963C1 /* Entity.cpp */; };
+		03B6C0B0136C77F800E40253 /* Game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DC61338235100A47E00 /* Game.cpp */; };
+		03B6C0B1136C77F800E40253 /* GUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3763773913385C7B003608BB /* GUI.cpp */; };
+		03B6C0B2136C77F800E40253 /* Input.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692C13317693008963C1 /* Input.cpp */; };
+		03B6C0B3136C77F800E40253 /* Level.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DCB1338236300A47E00 /* Level.cpp */; };
+		03B6C0B4136C77F800E40253 /* Monocle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB693913317693008963C1 /* Monocle.cpp */; };
+		03B6C0B5136C77F800E40253 /* MonocleToolkit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B2E135E5E9B00D92F21 /* MonocleToolkit.cpp */; };
+		03B6C0B6136C77F800E40253 /* Random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696913317693008963C1 /* Random.cpp */; };
+		03B6C0B7136C77F800E40253 /* Rect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F947BBE613532AC400952C81 /* Rect.cpp */; };
+		03B6C0B8136C77F800E40253 /* Scene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696B13317693008963C1 /* Scene.cpp */; };
+		03B6C0B9136C77F800E40253 /* TextureAtlas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEECC1367AFD100B62E27 /* TextureAtlas.cpp */; };
+		03B6C0BA136C77F800E40253 /* Tileset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DDF133823AA00A47E00 /* Tileset.cpp */; };
+		03B6C0BB136C77F800E40253 /* Transform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9132A0F134A0D8200567EAB /* Transform.cpp */; };
+		03B6C0BC136C77F800E40253 /* Tween.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697A13317693008963C1 /* Tween.cpp */; };
+		03B6C0BD136C77F800E40253 /* Vector2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697C13317693008963C1 /* Vector2.cpp */; };
+		03B6C0BE136C77F800E40253 /* Vector3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697E13317693008963C1 /* Vector3.cpp */; };
+		03B6C0BF136C780E00E40253 /* OggDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 037D6F6B136AF225001CFBB9 /* OggDecoder.cpp */; };
+		03B6C0C0136C780E00E40253 /* WaveDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 037D6F71136AF225001CFBB9 /* WaveDecoder.cpp */; };
+		03B6C0C1136C780E00E40253 /* Audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED71367B12000B62E27 /* Audio.cpp */; };
+		03B6C0C2136C780E00E40253 /* AudioDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEEEA1367BF2600B62E27 /* AudioDeck.cpp */; };
+		03B6C0C3136C780E00E40253 /* AudioCrypt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B7F135E81D600D92F21 /* AudioCrypt.cpp */; };
+		03B6C0C4136C780E00E40253 /* AudioAsset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B72135E74F500D92F21 /* AudioAsset.cpp */; };
+		03B6C0C5136C780E00E40253 /* AudioAssetReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 035BC67C1368D743002756A4 /* AudioAssetReader.cpp */; };
+		03B6C0C6136C780E00E40253 /* AudioDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B6F135E704D00D92F21 /* AudioDecoder.cpp */; };
+		03B6C0C7136C780E00E40253 /* AudioVis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEED91367B8C500B62E27 /* AudioVis.cpp */; };
+		03B6C0C8136C780E00E40253 /* VisCache2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEEDC1367BB4A00B62E27 /* VisCache2.cpp */; };
+		03B6C0C9136C780E00E40253 /* ChannelStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 037066A51369D25F00B7F9C4 /* ChannelStream.cpp */; };
+		03B6C0CA136C780E00E40253 /* fft.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 031FEEDF1367BB7100B62E27 /* fft.cpp */; };
+		03B6C0CB136C780E00E40253 /* CollisionData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B29135E5E0300D92F21 /* CollisionData.cpp */; };
+		03B6C0CC136C780E00E40253 /* PathCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9132A0813499ED200567EAB /* PathCollider.cpp */; };
+		03B6C0CD136C780E00E40253 /* CircleCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691A13317693008963C1 /* CircleCollider.cpp */; };
+		03B6C0CE136C780E00E40253 /* Collider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691C13317693008963C1 /* Collider.cpp */; };
+		03B6C0CF136C780E00E40253 /* PolygonCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D5D2133B0D57002953B0 /* PolygonCollider.cpp */; };
+		03B6C0D0136C780E00E40253 /* RectangleCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691E13317693008963C1 /* RectangleCollider.cpp */; };
+		03B6C0D1136C780E00E40253 /* Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CAD627133259DD009BC5F3 /* Sprite.cpp */; };
+		03B6C0D2136C780E00E40253 /* SpriteAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DD01338237600A47E00 /* SpriteAnimation.cpp */; };
+		03B6C0D3136C780E00E40253 /* Tilemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DD21338237600A47E00 /* Tilemap.cpp */; };
+		03B6C0D4136C780E00E40253 /* ImageBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B39135E5F0E00D92F21 /* ImageBrowser.cpp */; };
+		03B6C0D6136C780E00E40253 /* Node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D881B4FE13445142008EF89C /* Node.cpp */; };
+		03B6C0D7136C780E00E40253 /* FringeTile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D5FA133D3F3C002953B0 /* FringeTile.cpp */; };
+		03B6C0D8136C780E00E40253 /* LevelEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D5FE133D3F3C002953B0 /* LevelEditor.cpp */; };
+		03B6C0D9136C780E00E40253 /* PathMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D876F29413456E7500A021D8 /* PathMesh.cpp */; };
+		03B6C0DA136C780E00E40253 /* OpenGLTTFFontAsset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F947BBEB13532B1900952C81 /* OpenGLTTFFontAsset.cpp */; };
+		03B6C0DB136C780E00E40253 /* OpenGLGraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696613317693008963C1 /* OpenGLGraphics.cpp */; };
+		03B6C0DC136C780E00E40253 /* OpenGLTextureAsset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696713317693008963C1 /* OpenGLTextureAsset.cpp */; };
+		03B6C0DD136C781700E40253 /* CocoaEvents.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192B61335B0E800D2D264 /* CocoaEvents.mm */; };
+		03B6C0DE136C781700E40253 /* CocoaKeys.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3782F003133864AD0042BAE7 /* CocoaKeys.mm */; };
+		03B6C0DF136C781700E40253 /* CocoaOpenGL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192B31335A9C200D2D264 /* CocoaOpenGL.mm */; };
+		03B6C0E0136C781700E40253 /* CocoaPlatform.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192921335995600D2D264 /* CocoaPlatform.mm */; };
+		03B6C0E1136C781700E40253 /* CocoaWindowListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37B192BF13361FDA00D2D264 /* CocoaWindowListener.mm */; };
+		03B6C0E4136C784500E40253 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03B6C0E2136C784500E40253 /* OpenAL.framework */; };
+		03B6C0E5136C784500E40253 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03B6C0E3136C784500E40253 /* OpenGL.framework */; };
+		03B6C0E6136C79BD00E40253 /* stb_image.c in Sources */ = {isa = PBXBuildFile; fileRef = 03907B3C135E5F3B00D92F21 /* stb_image.c */; };
+		03B6C0E7136C7A1300E40253 /* Main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37AABF371333478A004E2D56 /* Main.cpp */; };
+		03B6C0E8136C7A1300E40253 /* AudioTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B67135E684700D92F21 /* AudioTest.cpp */; };
+		03B6C0E9136C7A1300E40253 /* LevelEditorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03907B33135E5EC400D92F21 /* LevelEditorTest.cpp */; };
+		03B6C0EA136C7A1300E40253 /* PuppetTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F947BBDC134C943600952C81 /* PuppetTest.cpp */; };
+		03B6C0EB136C7A1300E40253 /* Flash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37B1929513359BE600D2D264 /* Flash.cpp */; };
+		03B6C0EC136C7A1300E40253 /* Jumper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697113317693008963C1 /* Jumper.cpp */; };
+		03B6C0ED136C7A1300E40253 /* Ogmo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DF9133823E100A47E00 /* Ogmo.cpp */; };
+		03B6C0EE136C7A1300E40253 /* Pong.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697713317693008963C1 /* Pong.cpp */; };
+		03B6C0F1136C7A3500E40253 /* Monocle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03B6BFB5136C758A00E40253 /* Monocle.framework */; };
+		03B6C0F2136C7A4000E40253 /* Monocle.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 03B6BFB5136C758A00E40253 /* Monocle.framework */; };
+		03B6C0F5136C7B4F00E40253 /* Vorbis.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 03B6C0F3136C7B4F00E40253 /* Vorbis.framework */; };
+		03B6C0F6136C7B4F00E40253 /* GLEW.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 03B6C0F4136C7B4F00E40253 /* GLEW.framework */; };
 		37EA249B132F986900D216B0 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37EA249A132F986900D216B0 /* Cocoa.framework */; };
 		37EA24A5132F986900D216B0 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 37EA24A3132F986900D216B0 /* InfoPlist.strings */; };
-		37FB698013317693008963C1 /* Asset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691413317693008963C1 /* Asset.cpp */; };
-		37FB698213317693008963C1 /* CircleCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691A13317693008963C1 /* CircleCollider.cpp */; };
-		37FB698313317693008963C1 /* Collider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691C13317693008963C1 /* Collider.cpp */; };
-		37FB698413317693008963C1 /* RectangleCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB691E13317693008963C1 /* RectangleCollider.cpp */; };
-		37FB698513317693008963C1 /* Collision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692013317693008963C1 /* Collision.cpp */; };
-		37FB698613317693008963C1 /* Color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692213317693008963C1 /* Color.cpp */; };
-		37FB698813317693008963C1 /* Debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692613317693008963C1 /* Debug.cpp */; };
-		37FB698913317693008963C1 /* Entity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692913317693008963C1 /* Entity.cpp */; };
-		37FB698A13317693008963C1 /* Input.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB692C13317693008963C1 /* Input.cpp */; };
-		37FB699213317693008963C1 /* Monocle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB693913317693008963C1 /* Monocle.cpp */; };
-		37FB69AC13317693008963C1 /* OpenGLGraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696613317693008963C1 /* OpenGLGraphics.cpp */; };
-		37FB69AD13317693008963C1 /* OpenGLTextureAsset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696713317693008963C1 /* OpenGLTextureAsset.cpp */; };
-		37FB69AE13317693008963C1 /* Random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696913317693008963C1 /* Random.cpp */; };
-		37FB69AF13317693008963C1 /* Scene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB696B13317693008963C1 /* Scene.cpp */; };
-		37FB69B113317693008963C1 /* Jumper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697113317693008963C1 /* Jumper.cpp */; };
-		37FB69B313317693008963C1 /* Pong.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697713317693008963C1 /* Pong.cpp */; };
-		37FB69B413317693008963C1 /* Tween.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697A13317693008963C1 /* Tween.cpp */; };
-		37FB69B513317693008963C1 /* Vector2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697C13317693008963C1 /* Vector2.cpp */; };
-		37FB69B613317693008963C1 /* Vector3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37FB697E13317693008963C1 /* Vector3.cpp */; };
 		37FB69B813319030008963C1 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FB69B713319030008963C1 /* OpenGL.framework */; settings = {ATTRIBUTES = (Required, ); }; };
-		D881B50013445142008EF89C /* Node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D881B4FE13445142008EF89C /* Node.cpp */; };
-		F9132A0A13499ED200567EAB /* PathCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9132A0813499ED200567EAB /* PathCollider.cpp */; };
-		F9132A11134A0D8200567EAB /* Transform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9132A0F134A0D8200567EAB /* Transform.cpp */; };
-		F9132A14134A0D8C00567EAB /* Camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9132A12134A0D8C00567EAB /* Camera.cpp */; };
-		F9257DC81338235100A47E00 /* Game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DC61338235100A47E00 /* Game.cpp */; };
-		F9257DCD1338236300A47E00 /* Level.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DCB1338236300A47E00 /* Level.cpp */; };
-		F9257DD41338237600A47E00 /* SpriteAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DD01338237600A47E00 /* SpriteAnimation.cpp */; };
-		F9257DD51338237600A47E00 /* Tilemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DD21338237600A47E00 /* Tilemap.cpp */; };
-		F9257DE1133823AA00A47E00 /* Tileset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DDF133823AA00A47E00 /* Tileset.cpp */; };
-		F9257DFB133823E100A47E00 /* Ogmo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9257DF9133823E100A47E00 /* Ogmo.cpp */; };
-		F947BBDF134C943600952C81 /* PuppetTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F947BBDC134C943600952C81 /* PuppetTest.cpp */; };
-		F947BBE813532AC400952C81 /* Rect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F947BBE613532AC400952C81 /* Rect.cpp */; };
-		F947BBED13532B1900952C81 /* OpenGLTTFFontAsset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F947BBEB13532B1900952C81 /* OpenGLTTFFontAsset.cpp */; };
-		F9F7D5D4133B0D57002953B0 /* PolygonCollider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D5D2133B0D57002953B0 /* PolygonCollider.cpp */; };
-		F9F7D600133D3F3C002953B0 /* FringeTile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D5FA133D3F3C002953B0 /* FringeTile.cpp */; };
-		F9F7D602133D3F3C002953B0 /* LevelEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D5FE133D3F3C002953B0 /* LevelEditor.cpp */; };
-		F9F7D63A13457F3B002953B0 /* XMLFileNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D63813457F3B002953B0 /* XMLFileNode.cpp */; };
-		F9F7D63D13457F46002953B0 /* FileNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D63B13457F46002953B0 /* FileNode.cpp */; };
-		F9F7D64313457F5C002953B0 /* PathMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9F7D64113457F5C002953B0 /* PathMesh.cpp */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		03B6C0EF136C7A2200E40253 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 37EA248D132F986800D216B0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 03B6BFB4136C758A00E40253;
+			remoteInfo = Monocle;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		037D6FBE136B0256001CFBB9 /* Copy Files */ = {
@@ -96,10 +117,22 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				037D6FC2136B027F001CFBB9 /* GLEW.framework in Copy Files */,
-				037D6FC3136B027F001CFBB9 /* Vorbis.framework in Copy Files */,
+				03B6C0F5136C7B4F00E40253 /* Vorbis.framework in Copy Files */,
+				03B6C0F6136C7B4F00E40253 /* GLEW.framework in Copy Files */,
+				03B6C0F2136C7A4000E40253 /* Monocle.framework in Copy Files */,
 			);
 			name = "Copy Files";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03B6C01F136C779500E40253 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				03B6C020136C77A000E40253 /* GLEW.framework in CopyFiles */,
+				03B6C021136C77A000E40253 /* Vorbis.framework in CopyFiles */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -133,7 +166,6 @@
 		037D6F70136AF225001CFBB9 /* vorbisfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vorbisfile.h; sourceTree = "<group>"; };
 		037D6F71136AF225001CFBB9 /* WaveDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaveDecoder.cpp; sourceTree = "<group>"; };
 		037D6F72136AF225001CFBB9 /* WaveDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaveDecoder.h; sourceTree = "<group>"; };
-		037D6F83136AFB51001CFBB9 /* Ogg.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Ogg.framework; path = ../../../Libs/MacOSX/Ogg.framework; sourceTree = "<group>"; };
 		037D6F84136AFB51001CFBB9 /* Vorbis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vorbis.framework; path = ../../../Libs/MacOSX/Vorbis.framework; sourceTree = "<group>"; };
 		037D6FBB136AFE94001CFBB9 /* GLEW.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLEW.framework; path = ../../../Libs/MacOSX/GLEW.framework; sourceTree = "<group>"; };
 		037D6FBF136B027E001CFBB9 /* GLEW.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLEW.framework; path = ../../../Libs/MacOSX/GLEW.framework; sourceTree = "<group>"; };
@@ -158,6 +190,14 @@
 		03907B7F135E81D600D92F21 /* AudioCrypt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioCrypt.cpp; sourceTree = "<group>"; };
 		03907B80135E81D700D92F21 /* AudioCrypt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioCrypt.h; sourceTree = "<group>"; };
 		03A1D875135F297A00831F9E /* Editor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Editor.cpp; path = ../../../Code/Editor.cpp; sourceTree = "<group>"; };
+		03B6BFB5136C758A00E40253 /* Monocle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Monocle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		03B6BFB9136C758A00E40253 /* Monocle-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Monocle-Info.plist"; sourceTree = "<group>"; };
+		03B6BFBB136C758A00E40253 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		03B6BFBD136C758A00E40253 /* Monocle-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Monocle-Prefix.pch"; sourceTree = "<group>"; };
+		03B6C0E2136C784500E40253 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
+		03B6C0E3136C784500E40253 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		03B6C0F3136C7B4F00E40253 /* Vorbis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vorbis.framework; path = ../../../Libs/MacOSX/Vorbis.framework; sourceTree = "<group>"; };
+		03B6C0F4136C7B4F00E40253 /* GLEW.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLEW.framework; path = ../../../Libs/MacOSX/GLEW.framework; sourceTree = "<group>"; };
 		3763773913385C7B003608BB /* GUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GUI.cpp; path = ../../../Code/GUI.cpp; sourceTree = "<group>"; };
 		3763773A13385C7B003608BB /* GUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GUI.h; path = ../../../Code/GUI.h; sourceTree = "<group>"; };
 		3782F002133864AD0042BAE7 /* CocoaKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CocoaKeys.h; path = ../../../Code/Cocoa/CocoaKeys.h; sourceTree = "<group>"; };
@@ -278,10 +318,23 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		03B6BFB1136C758A00E40253 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03B6C0E4136C784500E40253 /* OpenAL.framework in Frameworks */,
+				03B6C0E5136C784500E40253 /* OpenGL.framework in Frameworks */,
+				03B6BFB6136C758A00E40253 /* Cocoa.framework in Frameworks */,
+				03B6C01D136C778A00E40253 /* GLEW.framework in Frameworks */,
+				03B6C01E136C778A00E40253 /* Vorbis.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		37EA2493132F986900D216B0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				03B6C0F1136C7A3500E40253 /* Monocle.framework in Frameworks */,
 				03907B41135E618F00D92F21 /* OpenAL.framework in Frameworks */,
 				37FB69B813319030008963C1 /* OpenGL.framework in Frameworks */,
 				37EA249B132F986900D216B0 /* Cocoa.framework in Frameworks */,
@@ -384,6 +437,24 @@
 			path = AudioTest;
 			sourceTree = "<group>";
 		};
+		03B6BFB7136C758A00E40253 /* Monocle */ = {
+			isa = PBXGroup;
+			children = (
+				03B6BFB8136C758A00E40253 /* Supporting Files */,
+			);
+			path = Monocle;
+			sourceTree = "<group>";
+		};
+		03B6BFB8136C758A00E40253 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				03B6BFB9136C758A00E40253 /* Monocle-Info.plist */,
+				03B6BFBA136C758A00E40253 /* InfoPlist.strings */,
+				03B6BFBD136C758A00E40253 /* Monocle-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		37B1929413359BE600D2D264 /* Flash */ = {
 			isa = PBXGroup;
 			children = (
@@ -442,10 +513,16 @@
 		37EA248B132F986800D216B0 = {
 			isa = PBXGroup;
 			children = (
+				03B6C0F3136C7B4F00E40253 /* Vorbis.framework */,
+				03B6C0F4136C7B4F00E40253 /* GLEW.framework */,
+				03B6BFB5136C758A00E40253 /* Monocle.framework */,
+				03B6C0E2136C784500E40253 /* OpenAL.framework */,
+				03B6C0E3136C784500E40253 /* OpenGL.framework */,
 				037D6FBF136B027E001CFBB9 /* GLEW.framework */,
 				037D6FC0136B027E001CFBB9 /* Vorbis.framework */,
-				37FB691313317656008963C1 /* Monocle */,
+				37FB691313317656008963C1 /* Monocle Code */,
 				37EA24A0132F986900D216B0 /* MonocleTest */,
+				03B6BFB7136C758A00E40253 /* Monocle */,
 				37EA2499132F986900D216B0 /* Frameworks */,
 				37EA2497132F986900D216B0 /* Products */,
 			);
@@ -463,7 +540,6 @@
 			isa = PBXGroup;
 			children = (
 				037D6FBB136AFE94001CFBB9 /* GLEW.framework */,
-				037D6F83136AFB51001CFBB9 /* Ogg.framework */,
 				037D6F84136AFB51001CFBB9 /* Vorbis.framework */,
 				03907B40135E618F00D92F21 /* OpenAL.framework */,
 				37EA249A132F986900D216B0 /* Cocoa.framework */,
@@ -501,7 +577,7 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		37FB691313317656008963C1 /* Monocle */ = {
+		37FB691313317656008963C1 /* Monocle Code */ = {
 			isa = PBXGroup;
 			children = (
 				03907B58135E644400D92F21 /* Audio */,
@@ -571,7 +647,7 @@
 				37FB697E13317693008963C1 /* Vector3.cpp */,
 				37FB697F13317693008963C1 /* Vector3.h */,
 			);
-			name = Monocle;
+			name = "Monocle Code";
 			sourceTree = "<group>";
 		};
 		37FB691913317693008963C1 /* Colliders */ = {
@@ -686,7 +762,36 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		03B6BFB2136C758A00E40253 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		03B6BFB4136C758A00E40253 /* Monocle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03B6BFC0136C758A00E40253 /* Build configuration list for PBXNativeTarget "Monocle" */;
+			buildPhases = (
+				03B6BFB0136C758A00E40253 /* Sources */,
+				03B6BFB1136C758A00E40253 /* Frameworks */,
+				03B6C01F136C779500E40253 /* CopyFiles */,
+				03B6BFB2136C758A00E40253 /* Headers */,
+				03B6BFB3136C758A00E40253 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Monocle;
+			productName = Monocle;
+			productReference = 03B6BFB5136C758A00E40253 /* Monocle.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		37EA2495132F986900D216B0 /* MonocleTest */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 37EA24B4132F986900D216B0 /* Build configuration list for PBXNativeTarget "MonocleTest" */;
@@ -700,6 +805,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				03B6C0F0136C7A2200E40253 /* PBXTargetDependency */,
 			);
 			name = MonocleTest;
 			productName = MonocleTest;
@@ -726,12 +832,21 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				03B6BFB4136C758A00E40253 /* Monocle */,
 				37EA2495132F986900D216B0 /* MonocleTest */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		03B6BFB3136C758A00E40253 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03B6BFBC136C758A00E40253 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		37EA2494132F986900D216B0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -760,88 +875,112 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		03B6BFB0136C758A00E40253 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03B6C0E6136C79BD00E40253 /* stb_image.c in Sources */,
+				03B6C0DD136C781700E40253 /* CocoaEvents.mm in Sources */,
+				03B6C0DE136C781700E40253 /* CocoaKeys.mm in Sources */,
+				03B6C0DF136C781700E40253 /* CocoaOpenGL.mm in Sources */,
+				03B6C0E0136C781700E40253 /* CocoaPlatform.mm in Sources */,
+				03B6C0E1136C781700E40253 /* CocoaWindowListener.mm in Sources */,
+				03B6C0BF136C780E00E40253 /* OggDecoder.cpp in Sources */,
+				03B6C0C0136C780E00E40253 /* WaveDecoder.cpp in Sources */,
+				03B6C0C1136C780E00E40253 /* Audio.cpp in Sources */,
+				03B6C0C2136C780E00E40253 /* AudioDeck.cpp in Sources */,
+				03B6C0C3136C780E00E40253 /* AudioCrypt.cpp in Sources */,
+				03B6C0C4136C780E00E40253 /* AudioAsset.cpp in Sources */,
+				03B6C0C5136C780E00E40253 /* AudioAssetReader.cpp in Sources */,
+				03B6C0C6136C780E00E40253 /* AudioDecoder.cpp in Sources */,
+				03B6C0C7136C780E00E40253 /* AudioVis.cpp in Sources */,
+				03B6C0C8136C780E00E40253 /* VisCache2.cpp in Sources */,
+				03B6C0C9136C780E00E40253 /* ChannelStream.cpp in Sources */,
+				03B6C0CA136C780E00E40253 /* fft.cpp in Sources */,
+				03B6C0CB136C780E00E40253 /* CollisionData.cpp in Sources */,
+				03B6C0CC136C780E00E40253 /* PathCollider.cpp in Sources */,
+				03B6C0CD136C780E00E40253 /* CircleCollider.cpp in Sources */,
+				03B6C0CE136C780E00E40253 /* Collider.cpp in Sources */,
+				03B6C0CF136C780E00E40253 /* PolygonCollider.cpp in Sources */,
+				03B6C0D0136C780E00E40253 /* RectangleCollider.cpp in Sources */,
+				03B6C0D1136C780E00E40253 /* Sprite.cpp in Sources */,
+				03B6C0D2136C780E00E40253 /* SpriteAnimation.cpp in Sources */,
+				03B6C0D3136C780E00E40253 /* Tilemap.cpp in Sources */,
+				03B6C0D4136C780E00E40253 /* ImageBrowser.cpp in Sources */,
+				03B6C0D6136C780E00E40253 /* Node.cpp in Sources */,
+				03B6C0D7136C780E00E40253 /* FringeTile.cpp in Sources */,
+				03B6C0D8136C780E00E40253 /* LevelEditor.cpp in Sources */,
+				03B6C0D9136C780E00E40253 /* PathMesh.cpp in Sources */,
+				03B6C0DA136C780E00E40253 /* OpenGLTTFFontAsset.cpp in Sources */,
+				03B6C0DB136C780E00E40253 /* OpenGLGraphics.cpp in Sources */,
+				03B6C0DC136C780E00E40253 /* OpenGLTextureAsset.cpp in Sources */,
+				03B6C0A0136C77F800E40253 /* XMLFileNode.cpp in Sources */,
+				03B6C0A1136C77F800E40253 /* tinyxml.cpp in Sources */,
+				03B6C0A2136C77F800E40253 /* tinyxmlerror.cpp in Sources */,
+				03B6C0A3136C77F800E40253 /* tinyxmlparser.cpp in Sources */,
+				03B6C0A5136C77F800E40253 /* Asset.cpp in Sources */,
+				03B6C0A6136C77F800E40253 /* Puppet.cpp in Sources */,
+				03B6C0A7136C77F800E40253 /* PuppetEditor.cpp in Sources */,
+				03B6C0A8136C77F800E40253 /* Assets.cpp in Sources */,
+				03B6C0A9136C77F800E40253 /* Camera.cpp in Sources */,
+				03B6C0AA136C77F800E40253 /* Collision.cpp in Sources */,
+				03B6C0AB136C77F800E40253 /* FileNode.cpp in Sources */,
+				03B6C0AC136C77F800E40253 /* Color.cpp in Sources */,
+				03B6C0AD136C77F800E40253 /* Debug.cpp in Sources */,
+				03B6C0AE136C77F800E40253 /* Editor.cpp in Sources */,
+				03B6C0AF136C77F800E40253 /* Entity.cpp in Sources */,
+				03B6C0B0136C77F800E40253 /* Game.cpp in Sources */,
+				03B6C0B1136C77F800E40253 /* GUI.cpp in Sources */,
+				03B6C0B2136C77F800E40253 /* Input.cpp in Sources */,
+				03B6C0B3136C77F800E40253 /* Level.cpp in Sources */,
+				03B6C0B4136C77F800E40253 /* Monocle.cpp in Sources */,
+				03B6C0B5136C77F800E40253 /* MonocleToolkit.cpp in Sources */,
+				03B6C0B6136C77F800E40253 /* Random.cpp in Sources */,
+				03B6C0B7136C77F800E40253 /* Rect.cpp in Sources */,
+				03B6C0B8136C77F800E40253 /* Scene.cpp in Sources */,
+				03B6C0B9136C77F800E40253 /* TextureAtlas.cpp in Sources */,
+				03B6C0BA136C77F800E40253 /* Tileset.cpp in Sources */,
+				03B6C0BB136C77F800E40253 /* Transform.cpp in Sources */,
+				03B6C0BC136C77F800E40253 /* Tween.cpp in Sources */,
+				03B6C0BD136C77F800E40253 /* Vector2.cpp in Sources */,
+				03B6C0BE136C77F800E40253 /* Vector3.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		37EA2492132F986900D216B0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				37FB698013317693008963C1 /* Asset.cpp in Sources */,
-				37FB698213317693008963C1 /* CircleCollider.cpp in Sources */,
-				37FB698313317693008963C1 /* Collider.cpp in Sources */,
-				37FB698413317693008963C1 /* RectangleCollider.cpp in Sources */,
-				37FB698513317693008963C1 /* Collision.cpp in Sources */,
-				37FB698613317693008963C1 /* Color.cpp in Sources */,
-				37FB698813317693008963C1 /* Debug.cpp in Sources */,
-				37FB698913317693008963C1 /* Entity.cpp in Sources */,
-				37FB698A13317693008963C1 /* Input.cpp in Sources */,
-				37FB699213317693008963C1 /* Monocle.cpp in Sources */,
-				37FB69AC13317693008963C1 /* OpenGLGraphics.cpp in Sources */,
-				37FB69AD13317693008963C1 /* OpenGLTextureAsset.cpp in Sources */,
-				37FB69AE13317693008963C1 /* Random.cpp in Sources */,
-				37FB69AF13317693008963C1 /* Scene.cpp in Sources */,
-				37FB69B113317693008963C1 /* Jumper.cpp in Sources */,
-				37FB69B313317693008963C1 /* Pong.cpp in Sources */,
-				37FB69B413317693008963C1 /* Tween.cpp in Sources */,
-				37FB69B513317693008963C1 /* Vector2.cpp in Sources */,
-				37FB69B613317693008963C1 /* Vector3.cpp in Sources */,
-				37CAD629133259DD009BC5F3 /* Sprite.cpp in Sources */,
-				37AABF3613333E29004E2D56 /* Assets.cpp in Sources */,
-				37AABF381333478A004E2D56 /* Main.cpp in Sources */,
-				37B192931335995600D2D264 /* CocoaPlatform.mm in Sources */,
-				37B1929713359BE600D2D264 /* Flash.cpp in Sources */,
-				37B1929D13359C9D00D2D264 /* tinyxml.cpp in Sources */,
-				37B1929E13359C9D00D2D264 /* tinyxmlerror.cpp in Sources */,
-				37B1929F13359C9D00D2D264 /* tinyxmlparser.cpp in Sources */,
-				37B192B41335A9C200D2D264 /* CocoaOpenGL.mm in Sources */,
-				37B192B71335B0E800D2D264 /* CocoaEvents.mm in Sources */,
-				37B192C013361FDA00D2D264 /* CocoaWindowListener.mm in Sources */,
-				F9257DC81338235100A47E00 /* Game.cpp in Sources */,
-				F9257DCD1338236300A47E00 /* Level.cpp in Sources */,
-				F9257DD41338237600A47E00 /* SpriteAnimation.cpp in Sources */,
-				F9257DD51338237600A47E00 /* Tilemap.cpp in Sources */,
-				F9257DE1133823AA00A47E00 /* Tileset.cpp in Sources */,
-				F9257DFB133823E100A47E00 /* Ogmo.cpp in Sources */,
-				3782F004133864AD0042BAE7 /* CocoaKeys.mm in Sources */,
-				F9F7D5D4133B0D57002953B0 /* PolygonCollider.cpp in Sources */,
-				F9F7D600133D3F3C002953B0 /* FringeTile.cpp in Sources */,
-				F9F7D602133D3F3C002953B0 /* LevelEditor.cpp in Sources */,
-				D881B50013445142008EF89C /* Node.cpp in Sources */,
-				F9F7D63A13457F3B002953B0 /* XMLFileNode.cpp in Sources */,
-				F9F7D63D13457F46002953B0 /* FileNode.cpp in Sources */,
-				F9F7D64313457F5C002953B0 /* PathMesh.cpp in Sources */,
-				F9132A0A13499ED200567EAB /* PathCollider.cpp in Sources */,
-				F9132A11134A0D8200567EAB /* Transform.cpp in Sources */,
-				F9132A14134A0D8C00567EAB /* Camera.cpp in Sources */,
-				F947BBDF134C943600952C81 /* PuppetTest.cpp in Sources */,
-				F947BBE813532AC400952C81 /* Rect.cpp in Sources */,
-				F947BBED13532B1900952C81 /* OpenGLTTFFontAsset.cpp in Sources */,
-				03907B2B135E5E0300D92F21 /* CollisionData.cpp in Sources */,
-				03907B30135E5E9B00D92F21 /* MonocleToolkit.cpp in Sources */,
-				03907B37135E5EC400D92F21 /* LevelEditorTest.cpp in Sources */,
-				03907B3B135E5F0E00D92F21 /* ImageBrowser.cpp in Sources */,
-				03907B3D135E5F3B00D92F21 /* stb_image.c in Sources */,
-				03907B6B135E684700D92F21 /* AudioTest.cpp in Sources */,
-				03907B71135E704D00D92F21 /* AudioDecoder.cpp in Sources */,
-				03907B73135E74F500D92F21 /* AudioAsset.cpp in Sources */,
-				03907B81135E81D700D92F21 /* AudioCrypt.cpp in Sources */,
-				03A1D876135F297A00831F9E /* Editor.cpp in Sources */,
-				031FEECE1367AFD100B62E27 /* TextureAtlas.cpp in Sources */,
-				031FEED41367B02100B62E27 /* Puppet.cpp in Sources */,
-				031FEED51367B02100B62E27 /* PuppetEditor.cpp in Sources */,
-				031FEED81367B12000B62E27 /* Audio.cpp in Sources */,
-				031FEEDB1367B8C600B62E27 /* AudioVis.cpp in Sources */,
-				031FEEDE1367BB4B00B62E27 /* VisCache2.cpp in Sources */,
-				031FEEE11367BB7200B62E27 /* fft.cpp in Sources */,
-				031FEEEC1367BF2700B62E27 /* AudioDeck.cpp in Sources */,
-				035BC67E1368D744002756A4 /* AudioAssetReader.cpp in Sources */,
-				037066A61369D25F00B7F9C4 /* ChannelStream.cpp in Sources */,
-				037D6F73136AF225001CFBB9 /* OggDecoder.cpp in Sources */,
-				037D6F74136AF225001CFBB9 /* WaveDecoder.cpp in Sources */,
+				03B6C0E7136C7A1300E40253 /* Main.cpp in Sources */,
+				03B6C0E8136C7A1300E40253 /* AudioTest.cpp in Sources */,
+				03B6C0E9136C7A1300E40253 /* LevelEditorTest.cpp in Sources */,
+				03B6C0EA136C7A1300E40253 /* PuppetTest.cpp in Sources */,
+				03B6C0EB136C7A1300E40253 /* Flash.cpp in Sources */,
+				03B6C0EC136C7A1300E40253 /* Jumper.cpp in Sources */,
+				03B6C0ED136C7A1300E40253 /* Ogmo.cpp in Sources */,
+				03B6C0EE136C7A1300E40253 /* Pong.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		03B6C0F0136C7A2200E40253 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 03B6BFB4136C758A00E40253 /* Monocle */;
+			targetProxy = 03B6C0EF136C7A2200E40253 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
+		03B6BFBA136C758A00E40253 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				03B6BFBB136C758A00E40253 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		37EA24A3132F986900D216B0 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -853,6 +992,64 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		03B6BFBE136C758A00E40253 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../../../Libs/MacOSX\"",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Monocle/Monocle-Prefix.pch";
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = (
+					MONOCLE_MAC,
+					MONOCLE_OPENGL,
+					MONOCLE_OPENAL,
+					MONOCLE_AUDIO_OGG,
+				);
+				INFOPLIST_FILE = "Monocle/Monocle-Info.plist";
+				INSTALL_PATH = "@executable_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Debug;
+		};
+		03B6BFBF136C758A00E40253 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../../../Libs/MacOSX\"",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Monocle/Monocle-Prefix.pch";
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = (
+					MONOCLE_MAC,
+					MONOCLE_OPENGL,
+					MONOCLE_OPENAL,
+					MONOCLE_AUDIO_OGG,
+				);
+				INFOPLIST_FILE = "Monocle/Monocle-Info.plist";
+				INSTALL_PATH = "@executable_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Release;
+		};
 		37EA24B2132F986900D216B0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -956,6 +1153,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		03B6BFC0136C758A00E40253 /* Build configuration list for PBXNativeTarget "Monocle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03B6BFBE136C758A00E40253 /* Debug */,
+				03B6BFBF136C758A00E40253 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		37EA2490132F986800D216B0 /* Build configuration list for PBXProject "MonocleTest" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
Changed MonocleTest into a separate target that uses the now built Monocle.Framework. Also had a small problem where Monocle wasn't looking in the Content/ folder of the resources path when running as a Release build.

Fixed with this line:
this->bundleResourcesPath = this->bundleResourcesPath + std::string("/Content");

The only issue I've got so far is that dependent projects must include not only Monocle.Framework, but also GLEW.Framework and Vorbis.Framework. Maybe static linking those to the library is the best bet.
