### PR TITLE
NSAutoreleasePool runtime errors on Mac

### DIFF
--- a/Core/Cocoa/CocoaPlatform.mm
+++ b/Core/Cocoa/CocoaPlatform.mm
@@ -102,6 +102,7 @@ namespace Monocle
 	{
 		//  Init event loop
 		Cocoa_RegisterApp();
+        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];        
 
         NSDictionary *env = [[NSProcessInfo processInfo] environment];
         if([[env objectForKey:@"MONOCLE_MAC_USE_CONTENT_PATH"] isEqualToString:@"true"]) {
@@ -133,7 +134,8 @@ namespace Monocle
 		//  Init internal timer
 		gettimeofday(&startTime, NULL);
 
-		return true;
+        [pool release];
+        return true;
 	}
 
 	Platform* Platform::instance;


### PR DESCRIPTION
We needed a pool in CocoaPlatform's init, and now we have one. Gets rid of some runtime errors that may or may not have become problems in the future, but were at least unaesthetic.
