### PR TITLE
premake helper script for easy external project generation

### DIFF
--- a/Core/premake4-monocle.lua
+++ b/Core/premake4-monocle.lua
@@ -23,10 +23,12 @@ project "MonocleCore"
 	configuration "Debug"
 		defines { "DEBUG" }
 		flags { "Symbols" }
+		targetsuffix "Debug"
 
 	configuration "Release"
 		defines { "NDEBUG" }
 		flags { "Optimize" } 
+
 	
 -- Old TinyXML Project (source just added to Core for now)
 --[[

--- a/premake4-helper.lua
+++ b/premake4-helper.lua
@@ -5,22 +5,27 @@ newoption
 	description	=	"Generate project files for a monocle test app"
 }
 
-if _OPTIONS["testapp"] ~= nil then
-	_MONOCLE_APP = _OPTIONS["testapp"]
+--Set app name
+if _MONOCLE_APP == nil then
+	if _OPTIONS["testapp"] ~= nil then
+		_MONOCLE_APP = _OPTIONS["testapp"]
+	else
+		_MONOCLE_APP = "Monocle"
+	end
 end
 
 -- jw: Fix premake4 --help
 if _ACTION ~= NIL then
-	_BUILD_BASE		= os.getcwd().."/Build/gen-".._ACTION.."-".._MONOCLE_APP
+	_BUILD_BASE		= _MONOCLE_BASE.."/Build/gen-".._ACTION.."-".._MONOCLE_APP
 else
-	_BUILD_BASE		= os.getcwd()
+	_BUILD_BASE		= _MONOCLE_BASE
 end
 
-_MONOCLE_INCLUDE		= _MONOCLE_BASE.."/Core"
+_MONOCLE_INCLUDE			= _MONOCLE_BASE.."/Core"
 _MONOCLE_EXTLIB_BASE		= _MONOCLE_BASE.."/Libraries"
 _MONOCLE_EXTLIB_LIB_INC		= _MONOCLE_EXTLIB_BASE.."/Compiled"
 
-
+--Preprocessor os specific defines 
 function monocle_os_defines()
 
 	defines {"MONOCLE_OPENGL","MONOCLE_OPENAL","MONOCLE_AUDIO_OGG"}
@@ -33,6 +38,7 @@ function monocle_os_defines()
 	end
 end
 
+--Get os specific directory name where precompiled libraries are present
 function monocle_get_os_lib_dir()
 	if os.is( "windows" ) == true then
 		return ("Win32")
@@ -43,22 +49,23 @@ function monocle_get_os_lib_dir()
 	end
 end
 
+--Set include directories for a 3rd party library 
 function monocle_extlib(name)
 	-- needs to be called for each library
 	includedirs{ (_MONOCLE_EXTLIB_BASE.."/"..name) }
 	-- os and compiler specific includes go here
 end
 
+--Set include paths for the Monocle libary directories
 function monocle_os_includedirs()
 	-- needs to be called once in a project
 	includedirs{ _MONOCLE_INCLUDE,_MONOCLE_EXTLIB_BASE }
 	libdirs { (_MONOCLE_EXTLIB_LIB_INC.."/"..monocle_get_os_lib_dir()) }
 end
 
+-- helper function to include header / library paths and link libraries by os
 function monocle_os_links()
-	-- helper function to include header / library paths and link libraries by os
-	-- nightmare for case-sensitivity on linux
-	links { "MonocleCore","TinyXML" }
+	links { "MonocleCore" }
 	
 	print( _MONOCLE_EXTLIB_BASE );
 	
@@ -78,6 +85,7 @@ function monocle_os_links()
 	end
 end
 
+--Generate path to target build directory
 function monocle_build_targetdir( suffix )
 	if suffix ~= nil then
 		targetdir (_BUILD_BASE.."-bin-"..suffix.."/")
@@ -86,13 +94,12 @@ function monocle_build_targetdir( suffix )
 	end
 end
 
-
-_MONOCLE_SOLUTION_NAME = "MonocleLibrary"
-if _OPTIONS["testapp"] ~= nil then
-	_MONOCLE_SOLUTION_NAME  = (_OPTIONS["testapp"].."Solution")
+--Ensure Monocle has a solution name
+if _MONOCLE_SOLUTION_NAME == nil then
+	_MONOCLE_SOLUTION_NAME = (_MONOCLE_APP.."Solution")
 end
 
-
+--Helper function to include a testapp project into solution
 function monocle_project_testapp( name )
 		_TESTAPP_PREMAKE_GENERIC_SCRIPT 	= "Tests/premake4-test-generic.lua"
 		_TESTAPP_PREMAKE_SCRIPT 			= "Tests/"..name.."/premake4-"..name..".lua"
@@ -104,6 +111,7 @@ function monocle_project_testapp( name )
 		end
 end
 
+--Helper function to include MonocleCore Library project into solution
 function monocle_project_corelib()
 	dofile( (_MONOCLE_BASE.."/Core/premake4-monocle.lua") );
 end

--- a/premake4-helper.lua
+++ b/premake4-helper.lua
@@ -16,9 +16,9 @@ end
 
 -- jw: Fix premake4 --help
 if _ACTION ~= NIL then
-	_BUILD_BASE		= _MONOCLE_BASE.."/Build/gen-".._ACTION.."-".._MONOCLE_APP
+	_BUILD_BASE		= _MONOCLE_APP_BASE.."/Build/gen-".._ACTION.."-".._MONOCLE_APP
 else
-	_BUILD_BASE		= _MONOCLE_BASE
+	_BUILD_BASE		= _MONOCLE_APP_BASE
 end
 
 _MONOCLE_INCLUDE			= _MONOCLE_BASE.."/Core"

--- a/premake4-helper.lua
+++ b/premake4-helper.lua
@@ -101,8 +101,8 @@ end
 
 --Helper function to include a testapp project into solution
 function monocle_project_testapp( name )
-		_TESTAPP_PREMAKE_GENERIC_SCRIPT 	= "Tests/premake4-test-generic.lua"
-		_TESTAPP_PREMAKE_SCRIPT 			= "Tests/"..name.."/premake4-"..name..".lua"
+		_TESTAPP_PREMAKE_GENERIC_SCRIPT 	= _MONOCLE_BASE.."/Tests/premake4-test-generic.lua"
+		_TESTAPP_PREMAKE_SCRIPT 			= _MONOCLE_BASE.."/Tests/"..name.."/premake4-"..name..".lua"
 		
 		if os.isfile( _TESTAPP_PREMAKE_SCRIPT ) then
 			dofile( _TESTAPP_PREMAKE_SCRIPT )

--- a/premake4-helper.lua
+++ b/premake4-helper.lua
@@ -1,0 +1,111 @@
+--premake4-helper.lua
+newoption
+{
+	trigger		=	"testapp",
+	description	=	"Generate project files for a monocle test app"
+}
+
+if _OPTIONS["testapp"] ~= nil then
+	_MONOCLE_APP = _OPTIONS["testapp"]
+end
+
+-- jw: Fix premake4 --help
+if _ACTION ~= NIL then
+	_BUILD_BASE		= os.getcwd().."/Build/gen-".._ACTION.."-".._MONOCLE_APP
+else
+	_BUILD_BASE		= os.getcwd()
+end
+
+_MONOCLE_INCLUDE		= _MONOCLE_BASE.."/Core"
+_MONOCLE_EXTLIB_BASE		= _MONOCLE_BASE.."/Libraries"
+_MONOCLE_EXTLIB_LIB_INC		= _MONOCLE_EXTLIB_BASE.."/Compiled"
+
+
+function monocle_os_defines()
+
+	defines {"MONOCLE_OPENGL","MONOCLE_OPENAL","MONOCLE_AUDIO_OGG"}
+	if os.is( "windows" ) == true then
+		defines {"MONOCLE_WINDOWS"}
+	elseif os.is( "linux" ) == true then
+		defines {"MONOCLE_LINUX"}
+	elseif os.is( "macosx" ) == true then
+		defines {"MONOCLE_MAC"}
+	end
+end
+
+function monocle_get_os_lib_dir()
+	if os.is( "windows" ) == true then
+		return ("Win32")
+	elseif os.is( "linux" ) == true then
+		return ("Linux")
+	elseif os.is( "macosx" ) == true then
+		return ("MacOSX")
+	end
+end
+
+function monocle_extlib(name)
+	-- needs to be called for each library
+	includedirs{ (_MONOCLE_EXTLIB_BASE.."/"..name) }
+	-- os and compiler specific includes go here
+end
+
+function monocle_os_includedirs()
+	-- needs to be called once in a project
+	includedirs{ _MONOCLE_INCLUDE,_MONOCLE_EXTLIB_BASE }
+	libdirs { (_MONOCLE_EXTLIB_LIB_INC.."/"..monocle_get_os_lib_dir()) }
+end
+
+function monocle_os_links()
+	-- helper function to include header / library paths and link libraries by os
+	-- nightmare for case-sensitivity on linux
+	links { "MonocleCore","TinyXML" }
+	
+	print( _MONOCLE_EXTLIB_BASE );
+	
+	monocle_extlib("glew")
+	monocle_extlib("openal")
+	monocle_extlib("ogg")
+	monocle_extlib("vorbis")
+	monocle_extlib("TinyXML")
+	
+	if os.is( "windows" ) == true then
+		links {"Winmm", "glew32s", "opengl32", "glu32", "openal32", "libogg_static","libvorbis_static","libvorbisfile_static"}
+	elseif os.is( "linux" ) == true then
+		links { "X11","GLEW","GL","GLU","openal","ogg","vorbis","vorbisfile","vorbisenc" }
+	elseif os.is( "macosx" ) == true then
+		links { "OpenGL.framework", "OpenAL.framework", "Cocoa.framework" }
+		links {"GLEW", "ogg","vorbis","vorbisfile","vorbisenc" }
+	end
+end
+
+function monocle_build_targetdir( suffix )
+	if suffix ~= nil then
+		targetdir (_BUILD_BASE.."-bin-"..suffix.."/")
+	else
+		targetdir (_BUILD_BASE.."-bin/")
+	end
+end
+
+
+_MONOCLE_SOLUTION_NAME = "MonocleLibrary"
+if _OPTIONS["testapp"] ~= nil then
+	_MONOCLE_SOLUTION_NAME  = (_OPTIONS["testapp"].."Solution")
+end
+
+
+function monocle_project_testapp( name )
+		_TESTAPP_PREMAKE_GENERIC_SCRIPT 	= "Tests/premake4-test-generic.lua"
+		_TESTAPP_PREMAKE_SCRIPT 			= "Tests/"..name.."/premake4-"..name..".lua"
+		
+		if os.isfile( _TESTAPP_PREMAKE_SCRIPT ) then
+			dofile( _TESTAPP_PREMAKE_SCRIPT )
+		else
+			dofile( _TESTAPP_PREMAKE_GENERIC_SCRIPT )
+		end
+end
+
+function monocle_project_corelib()
+	dofile( (_MONOCLE_BASE.."/Core/premake4-monocle.lua") );
+end
+
+--end of helper

--- a/premake4.lua
+++ b/premake4.lua
@@ -1,110 +1,15 @@
+--premake4.lua
 --
 -- Premake4 solution script
 -- Created: Airbash, May/03/2011
 -- Example usage: "premake4 --testapp=Pong vs2010"
 --
 
-newoption
-{
-	trigger		=	"testapp",
-	description	=	"Generate project files for a monocle test app"
-}
-
-
-_MONOCLE_APP = "Monocle"
-if _OPTIONS["testapp"] ~= nil then
-	_MONOCLE_APP = _OPTIONS["testapp"]
-end
-
-
-
+-- Required globals for helper script
+_MONOCLE_APP 			= "Monocle"	
 _MONOCLE_BASE			= os.getcwd()
 
--- jw: Fix premake4 --help
-if _ACTION ~= NIL then
-	_BUILD_BASE		= os.getcwd().."/Build/gen-".._ACTION.."-".._MONOCLE_APP
-else
-	_BUILD_BASE		= os.getcwd()
-end
-
-_MONOCLE_INCLUDE		= _MONOCLE_BASE.."/Core"
-_MONOCLE_EXTLIB_BASE		= _MONOCLE_BASE.."/Libraries"
-_MONOCLE_EXTLIB_LIB_INC		= _MONOCLE_EXTLIB_BASE.."/Compiled"
-
-
-function monocle_os_defines()
-
-	defines {"MONOCLE_OPENGL","MONOCLE_OPENAL","MONOCLE_AUDIO_OGG"}
-	if os.is( "windows" ) == true then
-		defines {"MONOCLE_WINDOWS"}
-	elseif os.is( "linux" ) == true then
-		defines {"MONOCLE_LINUX"}
-	elseif os.is( "macosx" ) == true then
-		defines {"MONOCLE_MAC"}
-	end
-end
-
-function monocle_get_os_lib_dir()
-	if os.is( "windows" ) == true then
-		return ("Win32")
-	elseif os.is( "linux" ) == true then
-		return ("Linux")
-	elseif os.is( "macosx" ) == true then
-		return ("MacOSX")
-	end
-end
-
-function monocle_extlib(name)
-	-- needs to be called for each library
-	includedirs{ (_MONOCLE_EXTLIB_BASE.."/"..name) }
-	-- os and compiler specific includes go here
-end
-
-function monocle_os_includedirs()
-	-- needs to be called once in a project
-	includedirs{ _MONOCLE_INCLUDE,_MONOCLE_EXTLIB_BASE }
-	libdirs { (_MONOCLE_EXTLIB_LIB_INC.."/"..monocle_get_os_lib_dir()) }
-end
-
-function monocle_os_links()
-	-- helper function to include header / library paths and link libraries by os
-	-- nightmare for case-sensitivity on linux
-	links { "MonocleCore" }
-	
-	print( _MONOCLE_EXTLIB_BASE );
-	
-	monocle_extlib("glew")
-	monocle_extlib("openal")
-	monocle_extlib("ogg")
-	monocle_extlib("vorbis")
-	--monocle_extlib("TinyXML")
-	
-	if os.is( "windows" ) == true then
-		links {"Winmm", "glew32s", "opengl32", "glu32", "openal32", "libogg_static","libvorbis_static","libvorbisfile_static"}
-	elseif os.is( "linux" ) == true then
-		-- this needs to be tested
-		links { "X11","GLEW","GL","GLU","openal","ogg","vorbis","vorbisfile","vorbisenc" }
-	elseif os.is( "macosx" ) == true then
-		links { "OpenGL.framework", "OpenAL.framework", "Cocoa.framework" }
-		links {"GLEW", "ogg","vorbis","vorbisfile","vorbisenc" }
-	end
-end
-
-function monocle_build_targetdir( suffix )
-	if suffix ~= nil then
-		targetdir (_BUILD_BASE.."-bin-"..suffix.."/")
-	else
-		targetdir (_BUILD_BASE.."-bin/")
-	end
-end
-
-
-
-_MONOCLE_SOLUTION_NAME = "MonocleLibrary"
-if _OPTIONS["testapp"] ~= nil then
-	_MONOCLE_SOLUTION_NAME  = (_OPTIONS["testapp"].."Solution")
-end
-
+dofile( (_MONOCLE_BASE.."/premake4-helper.lua") )
 
 --
 -- Monocle Solution
@@ -113,16 +18,10 @@ solution (_MONOCLE_SOLUTION_NAME)
 	basedir( _BUILD_BASE )
 	configurations { "Debug", "Release" }
 
+	--Test Application 
 	if _OPTIONS["testapp"] ~= NIL then
-		_TESTAPP_PREMAKE_GENERIC_SCRIPT 	= "Tests/premake4-test-generic.lua"
-		_TESTAPP_PREMAKE_SCRIPT 			= "Tests/".._OPTIONS["testapp"].."/premake4-".._OPTIONS["testapp"]..".lua"
-		
-		if os.isfile( _TESTAPP_PREMAKE_SCRIPT ) then
-			dofile( _TESTAPP_PREMAKE_SCRIPT )
-		else
-			dofile( _TESTAPP_PREMAKE_GENERIC_SCRIPT )
-		end
+		monocle_project_testapp( _OPTIONS["testapp"] )
 	end
 
 	-- Monocle Core Library
-	dofile( "Core/premake4-monocle.lua" );
+	monocle_project_corelib();

--- a/premake4.lua
+++ b/premake4.lua
@@ -6,8 +6,8 @@
 --
 
 -- Required globals for helper script
-_MONOCLE_APP 			= "Monocle"	
-_MONOCLE_BASE			= os.getcwd()
+_MONOCLE_APP_BASE		= os.getcwd()			--root directory of your project
+_MONOCLE_BASE			= os.getcwd()			--root directory for monocle
 
 dofile( (_MONOCLE_BASE.."/premake4-helper.lua") )
 

--- a/premake4.lua
+++ b/premake4.lua
@@ -11,6 +11,8 @@ _MONOCLE_BASE			= os.getcwd()			--root directory for monocle
 
 dofile( (_MONOCLE_BASE.."/premake4-helper.lua") )
 
+print( _MONOCLE_EXTLIB_BASE );
+
 --
 -- Monocle Solution
 --


### PR DESCRIPTION
Improved premake4 project generation scripts. 

All monocle specific functions and variables have been moved into premake4-helper.lua. Explanatory comments have been added above the monocle_\* functions.

MonocleCore debug static library is now created as MonocleCoreDebug.

premake4-helper.lua is intended to be included by projects that use premake to generate their Solutions with  premake. It contains helper functions to setup include paths and linking to static libraries.
