### PR TITLE
Mouse wheel not exposed through Monocle::Input

### DIFF
--- a/Core/Input.cpp
+++ b/Core/Input.cpp
@@ -70,6 +70,11 @@ namespace Monocle
 		return Scene::GetCamera()->position + (diff * Vector2(1/cameraZoom.x, 1/cameraZoom.y));
 	}
 
+	int Input::getMouseWheelScroll()
+	{
+	    return Platform::mouseWheel;
+	}
+
 	bool Input::IsMouseButtonHeld(MouseButton mouseButton)
 	{
 		return Platform::mouseButtons[(int)mouseButton];

--- a/Core/Input.h
+++ b/Core/Input.h
@@ -11,11 +11,11 @@ namespace Monocle
 {
 	//!
 	//! \brief Manages input for Monocle
-	//! 
+	//!
 	//! Is*Held = is key/mouse button currently being held
 	//! Is*Pressed = was the key/mouse button go down in this frame
 	//! Is*Released = did the key/mouse button go up in this frame
-	//! 
+	//!
 	class Input
 	{
 	public:
@@ -27,6 +27,7 @@ namespace Monocle
 		static Vector2 GetMousePosition();
 		// take camera into account
 		static Vector2 GetWorldMousePosition();
+		static int getMouseWheelScroll();
 		static bool IsMouseButtonHeld(MouseButton mouseButton);
 		static bool IsMouseButtonReleased(MouseButton mouseButton);
 		static bool IsMouseButtonPressed(MouseButton mouseButton);
@@ -46,16 +47,14 @@ namespace Monocle
 		static bool IsKeyMaskReleased(const std::string& mask);
 		static bool IsKeyMaskPressed(const std::string& mask);
 
-		
-
 		void Update();
-		
+
 	private:
 		static Input *instance;
 
 		bool previousKeys[KEY_MAX];
 		bool currentKeys[KEY_MAX];
-	
+
 		bool previousMouseButtons[MOUSE_BUTTON_MAX];
 		bool currentMouseButtons[MOUSE_BUTTON_MAX];
 

--- a/Core/Linux/LinuxPlatform.cpp
+++ b/Core/Linux/LinuxPlatform.cpp
@@ -177,6 +177,7 @@ namespace Monocle
 
         BindLocalKey(XK_space, KEY_SPACE);
         BindLocalKey(XK_quotedbl, KEY_QUOTE);
+        BindLocalKey(XK_apostrophe, KEY_APOSTROPHE);
         BindLocalKey(XK_comma, KEY_COMMA);
         BindLocalKey(XK_minus, KEY_MINUS);
         BindLocalKey(XK_period, KEY_PERIOD);

--- a/Core/Platform.h
+++ b/Core/Platform.h
@@ -16,6 +16,7 @@ namespace Monocle
 		KEY_ESCAPE,
 		KEY_SPACE,
 		KEY_QUOTE,
+		KEY_APOSTROPHE,
 		KEY_COMMA,
 		KEY_MINUS,
 		KEY_PERIOD,
@@ -174,7 +175,7 @@ namespace Monocle
 		static bool IsActive();
 
 		void WindowSizeChanged(int w, int h);
-        
+
         static std::string GetDefaultContentPath();
 
 	private:


### PR DESCRIPTION
The Platform interface has a int mousewheel member, but it's not exposed through the Input class.  (The referenced commit includes the other issue I submitted about the apostrophe/quotes.  Is it possible for me to set it to ignore the commit in the middle since they don't touch the same files?)
