### PR TITLE
Linux mouse scrolling causes "Recieved unknown button" to be logged

### DIFF
--- a/Core/Linux/LinuxPlatform.cpp
+++ b/Core/Linux/LinuxPlatform.cpp
@@ -297,7 +297,9 @@ namespace Monocle
         XEvent event;
 
         while (XPending(LinuxPlatform::instance->hDisplay)) { XNextEvent(LinuxPlatform::instance->hDisplay, &event);
-            switch(event.type) {
+            bool mScrolled = false;
+		
+			switch(event.type) {
             case Expose: {
                     XExposeEvent &expose = event.xexpose;
                     glViewport(0, 0, expose.width, expose.height);
@@ -322,13 +324,13 @@ namespace Monocle
                         button = MOUSE_BUTTON_RIGHT; break;
                     // TODO check if 120 is the right amount and generalize code
                     case Button4:
-                        mouseScroll += 120; break;
+                        mouseScroll += 120; mScrolled = true; break;
                     case Button5:
-                        mouseScroll -= 120; break;
+                        mouseScroll -= 120; mScrolled = true; break;
                     }
 
-                    if(mouseScroll == 0)
-                        Platform::SetMouseButton(button,
+					if(!mScrolled)
+						Platform::SetMouseButton(button,
                                                  event.type == ButtonPress);
                     Platform::mousePosition = Vector2(event.xbutton.x,
                                                       event.xbutton.y);

--- a/Core/Linux/LinuxPlatform.cpp
+++ b/Core/Linux/LinuxPlatform.cpp
@@ -327,8 +327,9 @@ namespace Monocle
                         mouseScroll -= 120; break;
                     }
 
-                    Platform::SetMouseButton(button,
-                                             event.type == ButtonPress);
+                    if(mouseScroll == 0)
+                        Platform::SetMouseButton(button,
+                                                 event.type == ButtonPress);
                     Platform::mousePosition = Vector2(event.xbutton.x,
                                                       event.xbutton.y);
                 } break;


### PR DESCRIPTION
When the mouse scrolls, the event received is a buttonpress/release event, which caused SetMouseButton to be called when no button had actually been pressed.
