### PR TITLE
XCode 4 Fix

### DIFF
--- a/Core/Asset.cpp
+++ b/Core/Asset.cpp
@@ -39,8 +39,8 @@ namespace Monocle
 	std::string Asset::GetName()
 	{
 	    //Will this stop working correctly if the content path is changed?
-		int size = Assets::GetContentPath().size();
-		return filename.substr(size, filename.size() - size);
+		size_t size = Assets::GetContentPath().size();
+		return filename.substr(size, filename.size() - int(size));
 	}
     
     std::string Asset::GetExtension()

--- a/Core/Cocoa/CocoaPlatform.mm
+++ b/Core/Cocoa/CocoaPlatform.mm
@@ -241,7 +241,6 @@ namespace Monocle
 	}
 
     std::string Platform::GetDefaultContentPath() {
-//        return CocoaPlatform::instance->bundleResourcesPath;
-        return "../../Content/";
+        return CocoaPlatform::instance->bundleResourcesPath;
     }
 }

--- a/Core/Collision.cpp
+++ b/Core/Collision.cpp
@@ -93,6 +93,8 @@ namespace Monocle
 				}
 			}
 		}
+        
+        return NULL;
 	}
 
 	//OPTION: refactor to add multiple colliders? (consider carefully)

--- a/Core/LevelEditor/LevelEditor.cpp
+++ b/Core/LevelEditor/LevelEditor.cpp
@@ -142,6 +142,8 @@ namespace Monocle
 					case FTES_COLOR:
 						UpdateColor();
 						break;
+                    default:
+                        break;
 					}
 				}
 			}

--- a/Core/OpenGL/OpenGLGraphics.cpp
+++ b/Core/OpenGL/OpenGLGraphics.cpp
@@ -101,6 +101,8 @@ namespace Monocle
 			case BLEND_MULTIPLY:
 				glBlendFunc(GL_ZERO, GL_SRC_COLOR);
 				break;
+            default:
+                break;
 			}
 			instance->currentBlend = blend;
 		}

--- a/Project/Xcode4/MonocleTest/MonocleTests/MonocleTests.xcodeproj/project.pbxproj
+++ b/Project/Xcode4/MonocleTest/MonocleTests/MonocleTests.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 				0328BB9B136EFC3A0031F7A3 /* Main.cpp */,
 			);
 			name = "Test Selector";
+			path = ../Samples;
 			sourceTree = "<group>";
 		};
 		03836F19136EED5D006746F2 = {
@@ -159,7 +160,7 @@
 				03836F72136EEE56006746F2 /* PuppetTest */,
 			);
 			name = Tests;
-			path = ../../../../Tests;
+			path = ../../../../Samples;
 			sourceTree = "<group>";
 		};
 		03836F52136EEE56006746F2 /* AudioTest */ = {
@@ -388,6 +389,7 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(MONOCLE_LIBRARY_PATH)/Core\"",
 					"\"$(MONOCLE_LIBRARY_PATH)/Libraries\"",
+					"\"$(MONOCLE_LIBRARY_PATH)/Samples\"",
 				);
 				INFOPLIST_FILE = "MonocleTests/MonocleTests-Info.plist";
 				MONOCLE_CONTENT_PATH = "$(MONOCLE_LIBRARY_PATH)/Content";
@@ -414,6 +416,7 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(MONOCLE_LIBRARY_PATH)/Core\"",
 					"\"$(MONOCLE_LIBRARY_PATH)/Libraries\"",
+					"\"$(MONOCLE_LIBRARY_PATH)/Samples\"",
 				);
 				INFOPLIST_FILE = "MonocleTests/MonocleTests-Info.plist";
 				MONOCLE_CONTENT_PATH = "$(MONOCLE_LIBRARY_PATH)/Content";

--- a/Samples/Flash/Flash.cpp
+++ b/Samples/Flash/Flash.cpp
@@ -51,7 +51,7 @@ namespace Flash
 		if (texture != NULL)
 		{
 			Entity *entity = new Entity();
-			Sprite *sprite = new Sprite(Assets::GetContentPath() + textureSheet.name + "/" + name + ".png");
+			Sprite *sprite = new Sprite(textureSheet.name + "/" + name + ".png");
 			sprite->position = (texture->registrationPoint * -1) + Vector2(sprite->width, sprite->height)*0.5f;
 			//sprite->position = texture->registrationPoint * -1;
 			entity->SetGraphic(sprite);


### PR DESCRIPTION
These changes allow MonocleTests to be compiled on XCode 4, as well as reduce the amount of warnings on compilation.
