### PR TITLE
Shader.h None function causes compile error with X.h

### DIFF
--- a/Core/Graphics/Sprite.cpp
+++ b/Core/Graphics/Sprite.cpp
@@ -209,7 +209,7 @@ namespace Monocle
 			Graphics::RenderQuad(width, height, textureOffset, textureScale);
 
 		Graphics::PopMatrix();
-		Shader::None();
+		Shader::UseNone();
 
 		// show bounds, for editor/selection purposes
 		if ((Debug::showBounds || Debug::selectedEntity == entity) && entity->IsDebugLayer())
@@ -261,7 +261,7 @@ namespace Monocle
 		}
 		else
 		{
-			Shader::None();
+			Shader::UseNone();
 			delete this->shader;
 			this->shader = shader;
 		}

--- a/Core/OpenGL/OpenGLShader.cpp
+++ b/Core/OpenGL/OpenGLShader.cpp
@@ -184,7 +184,7 @@ namespace Monocle
 		textures[name] = textures.size()-1;
 	}
     
-	void Shader::None()
+	void Shader::UseNone()
 	{
 		glUseProgram(0);
 	}

--- a/Core/Shader.h
+++ b/Core/Shader.h
@@ -30,7 +30,7 @@ namespace Monocle
 		void SetUniformInt(const std::string &name, int value );
 		void SetUniformSampler2D(const std::string &name);
         
-		static void None();
+		static void UseNone();
         
 		unsigned int vertexShader;
 		unsigned int fragmentShader;


### PR DESCRIPTION
X.h in Xlib #defines None, so the shader function produces a compile error.
