### PR TITLE
Cleaner Log Output interface

### DIFF
--- a/Core/Debug.cpp
+++ b/Core/Debug.cpp
@@ -6,107 +6,166 @@
 
 namespace Monocle
 {
+	class Debug::DebugOutStream
+	{
+	public:
+		DebugOutStream() : logOut(), logFilename(""), outDest(LOG_COUT) {}
+
+		~DebugOutStream()
+		{
+			if(logOut.is_open())
+			{
+				logOut.close();
+			}
+		}
+
+		void SetLogFile(const std::string &filename)
+		{
+			if(filename == "")
+			{
+				outDest &= ~LOG_FILE;
+			}
+
+			if(filename != logFilename)
+			{
+				if(logOut.is_open())
+				{
+					logOut.close();
+				}
+
+				if(filename != "")
+				{
+					logOut.open(filename);
+				}
+
+				logFilename = filename;
+			}
+		}
+		
+		void SetDestination(int dest, const std::string &filename)
+		{
+			outDest = dest;
+
+			if(dest & LOG_FILE)
+			{
+				SetLogFile(filename);
+			}
+			else
+			{
+				SetLogFile("");
+			}
+		}
+
+		template <typename T>
+		DebugOutStream &operator<<(const T &obj)
+		{
+			if(outDest & LOG_FILE)
+			{
+				logOut << obj;
+			}
+			if(outDest & LOG_COUT)
+			{
+				std::cout << obj;
+			}
+			if(outDest & LOG_CERR)
+			{
+				std::cerr << obj;
+			}
+			if(outDest & LOG_CLOG)
+			{
+				std::clog << obj;
+			}
+
+			return *this;
+		}
+
+		DebugOutStream &operator<<(std::ostream& func(std::ostream&))
+		{
+			if(outDest & LOG_FILE)
+			{
+				logOut << func;
+			}
+			if(outDest & LOG_COUT)
+			{
+				std::cout << func;
+			}
+			if(outDest & LOG_CERR)
+			{
+				std::cerr << func;
+			}
+			if(outDest & LOG_CLOG)
+			{
+				std::clog << func;
+			}
+
+			return *this;
+		}
+	private:
+		std::ofstream logOut;
+		std::string logFilename;
+		int outDest;
+	};
+
 	bool Debug::render = false;
 	bool Debug::showBounds = false;
 	Entity *Debug::selectedEntity;
 	int Debug::layerMin = -50;
 	int Debug::layerMax = 50;
-	bool Debug::useFile = false;
-	bool Debug::useConsole = true;
-	
+
+	Debug::DebugOutStream Debug::outStream = Debug::DebugOutStream();
+
 	void Debug::Init()
 	{
 		render = false;
-		logout.open("monocle.log");
-		std::clog.rdbuf(logout.rdbuf());
 	}
 
 	void Debug::Log(const char *outputString)
 	{
-		if (useConsole)
-			std::cout << outputString << std::endl;
-		if (useFile)
-			std::clog << outputString << std::endl;
+		outStream << outputString << std::endl;
 	}
 
 	void Debug::Log(bool boolean)
 	{
-		if (useConsole)
-			std::cout << (boolean?"true":"false") << std::endl;
-		if (useFile)
-			std::clog << (boolean?"true":"false") << std::endl;
+		outStream << (boolean?"true":"false") << std::endl;
 	}
 
 	void Debug::Log(int num)
 	{
-		if (useConsole)
-			std::cout << num << std::endl;
-		if (useFile)
-			std::clog << num << std::endl;
+		outStream << num << std::endl;
 	}
 
 	void Debug::Log(long num)
 	{
-		if (useConsole)
-			std::cout << num << std::endl;
-		if (useFile)
-			std::clog << num << std::endl;
+		outStream << num << std::endl;
 	}
 
 	void Debug::Log(float num)
 	{
-		std::clog << num << std::endl;
+		outStream << num << std::endl;
 	}
 
 	void Debug::Log(double num)
 	{
-		if (useConsole)
-			std::cout << num << std::endl;
-		if (useFile)
-			std::clog << num << std::endl;
+		outStream << num << std::endl;
 	}
 
 	void Debug::Log(const Vector2& vec)
 	{
-		if (useConsole)
-			std::cout << "Vector2: (" << vec.x << ", " << vec.y << ")" << std::endl;
-		if (useFile)
-			std::clog << "Vector2: (" << vec.x << ", " << vec.y << ")" << std::endl;
+		outStream << "Vector2: (" << vec.x << ", " << vec.y << ")" << std::endl;
 	}
 
 	void Debug::Log(const Vector3& vec)
 	{
-		if (useConsole)
-			std::cout << "Vector3: (" << vec.x << ", " << vec.y << ", " << vec.z << ")" << std::endl;
-		if (useFile)
-			std::clog << "Vector3: (" << vec.x << ", " << vec.y << ", " << vec.z << ")" << std::endl;
+		outStream << "Vector3: (" << vec.x << ", " << vec.y << ", " << vec.z << ")" << std::endl;
 	}
 
 	void Debug::Log(const std::string& string)
 	{
-		if (useConsole)
-			std::cout << string << std::endl;
-		if (useFile)
-			std::clog << string << std::endl;
-	}
-	
-	void Debug::SetFileLogging(bool useFile)
-	{
-		Debug::useFile = useFile;
+		outStream << string << std::endl;
 	}
 
-	void Debug::SetConsoleLogging(bool useConsole)
+	void Debug::SetLogDestination(OutputDestFlags dest, const std::string &filename)
 	{
-		Debug::useConsole = useConsole;
-	}
-
-	bool Debug::GetFileLogging()
-	{
-		return useFile;
-	}
-
-	bool Debug::GetConsoleLogging()
-	{
-		return useConsole;
+		outStream.SetDestination(dest, filename);
 	}
 }

--- a/Core/Debug.h
+++ b/Core/Debug.h
@@ -14,7 +14,19 @@ namespace Monocle
 	//!
 	class Debug
 	{
+	private:
+		class DebugOutStream;
 	public:
+		typedef int OutputDestFlags;
+
+		enum OutputDest
+		{
+			LOG_FILE = 1,
+			LOG_COUT = 2,
+			LOG_CERR = 4,
+			LOG_CLOG = 8
+		};
+
 		static void Log(const char *string);
 		static void Log(bool boolean);
 		static void Log(int num);
@@ -24,12 +36,8 @@ namespace Monocle
 		static void Log(const Vector2& vec);
 		static void Log(const Vector3& vec);
 		static void Log(const std::string& string);
-		
-		static void SetFileLogging(bool useFile);
-		static void SetConsoleLogging(bool useConsole);
-		
-		static bool GetFileLogging();
-		static bool GetConsoleLogging();
+
+		static void SetLogDestination(OutputDestFlags dest, const std::string &filename = "monocle.log");
 
 		static bool render;
 		static bool showBounds;
@@ -44,11 +52,8 @@ namespace Monocle
 	protected:
 		friend class Game;
 		void Init();
-
     private:
-        std::ofstream logout;
-		static bool useConsole;
-		static bool useFile;
 
+		static DebugOutStream outStream;
 	};
 }


### PR DESCRIPTION
Additional output options can now be added easier.  One call can be used to set multiple output locations.  There is no longer a need to check class-level bools in every Debug::Log function, the streams are handled by the new DebugOutStream class.

--Debug::SetLogDestination(OutputDestFlags, const string&) added.
    This can be used to set multiple output locations, eg
    Debug::SetLogDestination(Debug::LOG_FILE | Debug::LOG_COUT,
    "myLog.log");
    The string argument is the filename if LOG_FILE flag is set.
--DebugOutStream class added, allowing all Debug::Log functions to simply call DebugOutStream << logArg << std::endl; without caring about what streams actually have to be written to.  DebugOutStream manages the
ostreams and the destination flags.
