### PR TITLE
Pixel Format Support for TextureAssets

### DIFF
--- a/Core/OpenGLES/OpenGLESTextureAsset.cpp
+++ b/Core/OpenGLES/OpenGLESTextureAsset.cpp
@@ -22,6 +22,18 @@
 
 namespace Monocle
 {
+	struct PixelFormat
+	{
+	private:
+		friend class TextureAsset;
+
+		PixelFormat(GLenum fmt) : glPixFormat(fmt) {}
+		GLenum glPixFormat;
+	};
+
+	PixelFormat TextureAsset::RGBA = PixelFormat(GL_RGBA);
+	PixelFormat TextureAsset::BGRA = PixelFormat(GL_BGRA);
+
 	TextureAsset::TextureAsset()
     : Asset(ASSET_TEXTURE)
 	{
@@ -32,8 +44,9 @@ namespace Monocle
         return this->premultiplied;
     }
     
-	void TextureAsset::Load(const unsigned char* data, int w, int h, FilterType filter, bool repeatX, bool repeatY, bool premultiply)
+	void TextureAsset::Load(const unsigned char* data, int w, int h, FilterType filter, bool repeatX, bool repeatY, bool premultiply, const PixelFormat &fmt)
 	{
+		this->format = &fmt;
 		this->filter = filter;
 		this->repeatX = repeatX;
 		this->repeatY = repeatY;
@@ -74,7 +87,7 @@ namespace Monocle
 		// mipmaps: OpenGL 1.4 version
 		//glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
         
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, format->glPixFormat, GL_UNSIGNED_BYTE, data);
         
         // Todo: Mipmaps?
 //        glGenerateMipmap(GL_TEXTURE_2D);
@@ -84,6 +97,7 @@ namespace Monocle
     
 	bool TextureAsset::Load(const std::string &filename, FilterType filter, bool repeatX, bool repeatY, bool premultiply)
 	{
+		this->format = &RGBA;
 		this->filter = filter;
 		this->repeatX = repeatX;
 		this->repeatY = repeatY;
@@ -132,7 +146,7 @@ namespace Monocle
 			// mipmaps: OpenGL 1.4 version
 			//glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
             
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, format->glPixFormat, GL_UNSIGNED_BYTE, data);
             
 			// mipmaps: OpenGL 3.0 version
 

--- a/Core/TextureAsset.h
+++ b/Core/TextureAsset.h
@@ -6,6 +6,8 @@ namespace Monocle
 {
 	class Vector2;
 	
+	struct PixelFormat;
+
 	class TextureAsset : public Asset
 	{
 	public:
@@ -19,7 +21,7 @@ namespace Monocle
 		//! \param repeatX [in] Whether or not the texture should be repeated on the x axis if necessary when rendered
 		//! \param repeatY [in] Whether or not the texture should be repeated on the y axis if necessary when rendered
         //! \param premultiply [in] Whether or not to apply premulitplication to the texture as it loads
-		void Load(const unsigned char* data, int w, int h, FilterType filter, bool repeatX, bool repeatY, bool premultiply = false);
+		void Load(const unsigned char* data, int w, int h, FilterType filter, bool repeatX, bool repeatY, bool premultiply = false, const PixelFormat &fmt = RGBA);
 		//! \brief Loads a texture from a file
 		//! \return Whether the load was successful.  If this is false, the texture is invalid and should not be used except to attempt another Load
 		//! \param filename [in] The filename to load from, relative to the current ContentPath
@@ -56,9 +58,11 @@ namespace Monocle
 		bool repeatX, repeatY;
         bool premultiplied;
  
+		static PixelFormat RGBA;
+		static PixelFormat BGRA;
 	private:
 		FilterType filter;
-		
+		const PixelFormat *format;
 	};
 }
  


### PR DESCRIPTION
TextureAssets now contain a PixelFormat member that dictates the pixel format of the loaded image.

I think stb_image converts everything into RGBA, so worrying about formats for Assets::RequestTexture(...) is unnecessary.

PixelFormat is a struct whose implementation is defined in OpenGLTextureAsset.cpp (or whatever other implementations end up being written).  I changed OpenGLESTextureAsset.cpp as well, but I can't test it compiles/runs properly.
