### PR TITLE
Addons structure

### DIFF
--- a/Addons/default/premake.lua
+++ b/Addons/default/premake.lua
@@ -1,0 +1,21 @@
+project ("Addon.$ADDON_NAME")
+	kind "StaticLib"
+	language "C++"
+	targetname "Monocle$ADDON_NAME"
+	basedir	( _BUILD_BASE )
+	
+	monocle_os_defines()
+	monocle_os_includedirs()
+	monocle_os_links()
+
+	files { _MONOCLE_BASE.."/Addons/$ADDON_NAME/**.cpp" }
+	files { _MONOCLE_BASE.."/Addons/$ADDON_NAME/**.h" }
+		
+	configuration "Debug"
+		defines { "DEBUG" }
+		flags { "Symbols" }
+		targetsuffix "Debug"
+			
+	configuration "Release"
+		defines { "NDEBUG" }
+		flags { "Optimize" } 

--- a/Addons/premake4-addons.lua
+++ b/Addons/premake4-addons.lua
@@ -1,0 +1,41 @@
+newoption
+{
+	trigger		= "create-addon",
+	value		= "ADDON",
+	description	= "Creates a new addon named ADDON in the Addons directory."
+}
+
+if _OPTIONS["create-addon"] ~= nil then
+	local addon = _OPTIONS["create-addon"]
+	print("Creating addon "..addon)
+
+	--print("mkdir \"".._MONOCLE_BASE.."/Addons/"..addon.."\"")
+	os.execute("mkdir \"".._MONOCLE_BASE.."/Addons/"..addon.."\"")
+	local files = os.matchfiles(_MONOCLE_BASE.."/Addons/default/*")
+	
+	print("Copying files from default...")
+	for k, f in pairs(files) do
+		local fin = assert(io.open(f, "r"))
+		local text = fin:read("*all")
+		fin:close()
+
+		text = text:gsub("$ADDON_NAME", addon)
+
+		local outfname = f:gsub("/default/", "/"..addon.."/")
+		local fout = assert(io.open(outfname, "w"))
+		fout:write(text)
+		fout:close()
+	end
+
+
+	os.exit(0)
+end
+
+function monocle_project_addons()
+	local addondirs = os.matchdirs(_MONOCLE_BASE.."/Addons/*")
+	for i, dir in pairs(addondirs) do
+		if dir:find("default") == nil then
+			dofile(dir.."/premake.lua")
+		end
+	end
+end

--- a/premake4-helper.lua
+++ b/premake4-helper.lua
@@ -71,7 +71,6 @@ end
 
 -- convenient if one wants to build a project that includes all the core source 'n libs
 function monocle_os_links_base()
-	print( _MONOCLE_EXTLIB_BASE );
 	
 	monocle_extlib("glew")
 	monocle_extlib("openal")

--- a/premake4.lua
+++ b/premake4.lua
@@ -10,8 +10,9 @@ _MONOCLE_APP_BASE		= os.getcwd()			--root directory of your project
 _MONOCLE_BASE			= os.getcwd()			--root directory for monocle
 
 dofile( (_MONOCLE_BASE.."/premake4-helper.lua") )
+dofile( (_MONOCLE_BASE.."/Addons/premake4-addons.lua") )
 
-print( _MONOCLE_EXTLIB_BASE );
+--print( _MONOCLE_EXTLIB_BASE );
 
 --
 -- Monocle Solution
@@ -24,6 +25,8 @@ solution (_MONOCLE_SOLUTION_NAME)
 	if _OPTIONS["testapp"] ~= NIL then
 		monocle_project_testapp( _OPTIONS["testapp"] )
 	end
+
+	monocle_project_addons()
 
 	-- Monocle Core Library
 	monocle_project_corelib();


### PR DESCRIPTION
This adds an addons directory so that we can add side projects that can be compiled separately and only used if wanted.

New addons can be generated by running premake with the argument --create-addon=ADDON where ADDON is the name of the new addon.  The script will create the /Addons/ADDON directory, complete with a premake script to generate a project for the addon with any .cpp/.h files in that dir.  The script will then terminate, so you will need to run the premake command again with the regular options to actually generate the project files.

Each addon in the Addons directory gets its own project when the project files are generated, and they get compiled into static libraries named MonocleADDON{Debug}.lib.  That way the developer can pick and choose what non-core functionality they want to build and include.
