### PR TITLE
Various compilation errors on OSX

### DIFF
--- a/Core/Audio/ChannelStream.cpp
+++ b/Core/Audio/ChannelStream.cpp
@@ -273,8 +273,8 @@ namespace Monocle
         this->buffers = new unsigned int [NUM_BUFFERS];
         this->obtainedBuffer = new unsigned char [BUFFER_SIZE];
         
-        memset(this->buffers,0,sizeof(this->buffers));
-        memset(this->obtainedBuffer,0,sizeof(this->obtainedBuffer));
+        memset(this->buffers,0,sizeof(*this->buffers));
+        memset(this->obtainedBuffer,0,sizeof(*this->obtainedBuffer));
         
         this->started = false;
         this->startBuffer=0;

--- a/Core/Cocoa/CocoaEvents.mm
+++ b/Core/Cocoa/CocoaEvents.mm
@@ -60,11 +60,11 @@ CreateApplicationMenus(void)
 	NSString *appName;
 	NSString *title;
 	NSMenu *appleMenu;
-	NSMenu *windowMenu;
+	//NSMenu *windowMenu;
 	NSMenuItem *menuItem;
 
 	/* Create the main menu bar */
-	[NSApp setMainMenu:[[NSMenu alloc] init]];
+	[NSApp setMainMenu:[[[NSMenu alloc] init] autorelease]];
 
 	/* Create the application menu */
 	appName = GetApplicationName();

--- a/Core/Cocoa/CocoaKeys.mm
+++ b/Core/Cocoa/CocoaKeys.mm
@@ -147,6 +147,7 @@ void Cocoa_HandleKeyEvent(NSEvent *event)
 	else {
         printf("unknown scancode: %d", scancode);
 		//Debug::Log("Unknown scancode");
+		return;
 	}
 
 	switch ([event type]) {

--- a/Core/Debug.cpp
+++ b/Core/Debug.cpp
@@ -35,7 +35,9 @@ namespace Monocle
 
 				if(filename != "")
 				{
-					logOut.open(filename);
+					char *cfilename = strdup(filename.c_str());
+					logOut.open(cfilename);
+					free(cfilename);
 				}
 
 				logFilename = filename;
@@ -112,8 +114,11 @@ namespace Monocle
 	int Debug::layerMin = -50;
 	int Debug::layerMax = 50;
 
-	Debug::DebugOutStream Debug::outStream = Debug::DebugOutStream();
-
+	Debug::DebugOutStream Debug::outStream
+#ifndef MONOCLE_MAC
+     = Debug::DebugOutStream()
+#endif
+    ;
 	void Debug::Init()
 	{
 		render = false;

--- a/Core/Macros.h
+++ b/Core/Macros.h
@@ -5,8 +5,13 @@
 		MIN returns the smaller of the arguments.
 		MAX returns the larger of the arguments.
 */
+#ifndef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b)) 
+#endif
+
+#ifndef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b)) 
+#endif
 
 /*	CLAMP
 		Combines min and max in one macro for convenience.

--- a/Core/OpenGL/OpenGLGraphics.cpp
+++ b/Core/OpenGL/OpenGLGraphics.cpp
@@ -394,7 +394,7 @@ namespace Monocle
         glBegin(GL_QUADS);
         for (int i = 0; i < text.size(); i++)
         {
-            char c = text[i];
+            unsigned char c = text[i];
 			if ((c >= 32) && (c < 128))
 			{
 				font.GetGlyphData(c, &x, &y, verts, texCoords);

--- a/Core/OpenGL/OpenGLTextureAsset.cpp
+++ b/Core/OpenGL/OpenGLTextureAsset.cpp
@@ -160,7 +160,7 @@ namespace Monocle
 			glGenerateMipmap(GL_TEXTURE_2D);
 #else
  
-			gluBuild2DMipmaps(GL_TEXTURE_2D, GL_RGBA8, width, height, fmt.glPixFormat, GL_UNSIGNED_BYTE, data);
+			gluBuild2DMipmaps(GL_TEXTURE_2D, GL_RGBA8, width, height, format->glPixFormat, GL_UNSIGNED_BYTE, data);
 #endif
  
 			//Debug::Log("Loaded texture: " + filename);

--- a/Libraries/stb/stb_image.c
+++ b/Libraries/stb/stb_image.c
@@ -1,4 +1,4 @@
-/* stbi-1.29 - public domain JPEG/PNG reader - http://nothings.org/stb_image.c
+/* stbi-1.33 - public domain JPEG/PNG reader - http://nothings.org/stb_image.c
    when you control the images you're loading
                                      no warranty implied; use at your own risk
 
@@ -17,36 +17,25 @@
       HDR (radiance rgbE format)
       PIC (Softimage PIC)
 
-      - decoded from memory or through stdio FILE (define STBI_NO_STDIO to remove code)
-      - supports installable dequantizing-IDCT, YCbCr-to-RGB conversion (define STBI_SIMD)
+      - decode from memory or through FILE (define STBI_NO_STDIO to remove code)
+      - decode from arbitrary I/O callbacks
+      - overridable dequantizing-IDCT, YCbCr-to-RGB conversion (define STBI_SIMD)
 
    Latest revisions:
+      1.33 (2011-07-14) minor fixes suggested by Dave Moore
+      1.32 (2011-07-13) info support for all filetypes (SpartanJ)
+      1.31 (2011-06-19) a few more leak fixes, bug in PNG handling (SpartanJ)
+      1.30 (2011-06-11) added ability to load files via io callbacks (Ben Wenger)
       1.29 (2010-08-16) various warning fixes from Aurelien Pocheville 
       1.28 (2010-08-01) fix bug in GIF palette transparency (SpartanJ)
       1.27 (2010-08-01) cast-to-uint8 to fix warnings (Laurent Gomila)
                         allow trailing 0s at end of image data (Laurent Gomila)
       1.26 (2010-07-24) fix bug in file buffering for PNG reported by SpartanJ
-      1.25 (2010-07-17) refix trans_data warning (Won Chun)
-      1.24 (2010-07-12) perf improvements reading from files
-                        minor perf improvements for jpeg
-                        deprecated type-specific functions in hope of feedback
-                        attempt to fix trans_data warning (Won Chun)
-      1.23              fixed bug in iPhone support
-      1.22 (2010-07-10) removed image *writing* support to stb_image_write.h
-                        stbi_info support from Jetro Lauha
-                        GIF support from Jean-Marc Lienher
-                        iPhone PNG-extensions from James Brown
-                        warning-fixes from Nicolas Schulz and Janez Zemva
-      1.21              fix use of 'uint8' in header (reported by jon blow)
-      1.20              added support for Softimage PIC, by Tom Seddon
 
    See end of file for full revision history.
 
    TODO:
       stbi_info support for BMP,PSD,HDR,PIC
-      rewrite stbi_info and load_file variations to share file handling code
-           (current system allows individual functions to be called directly,
-           since each does all the work, but I doubt anyone uses this in practice)
 
 
  ============================    Contributors    =========================
@@ -63,7 +52,10 @@
  Extensions, features                            Janez Zemva                
     Jetro Lauha (stbi_info)                      Jonathan Blow              
     James "moose2000" Brown (iPhone PNG)         Laurent Gomila                             
-                                                 Aruelien Pocheville
+    Ben "Disch" Wenger (io callbacks)            Aruelien Pocheville
+    Martin "SpartanJ" Golini                     Ryamond Barbiero
+                                                 David Woo
+                                                 
 
  If your name should be here but isn't, let Sean know.
 
@@ -91,6 +83,7 @@
 //    // ... process data if not NULL ... 
 //    // ... x = width, y = height, n = # 8-bit components per pixel ...
 //    // ... replace '0' with '1'..'4' to force that many components per pixel
+//    // ... but 'n' will always be the number that it would have been if you said 0
 //    stbi_image_free(data)
 //
 // Standard parameters:
@@ -177,8 +170,26 @@
 // not), using:
 //
 //     stbi_is_hdr(char *filename);
+//
+// ===========================================================================
+//
+// I/O callbacks
+//
+// I/O callbacks allow you to read from arbitrary sources, like packaged
+// files or some other source. Data read from callbacks are processed
+// through a small internal buffer (currently 128 bytes) to try to reduce
+// overhead. 
+//
+// The three functions you must define are "read" (reads some bytes of data),
+// "skip" (skips some bytes of data), "eof" (reports if the stream is at the end).
+
 
 #ifndef STBI_NO_STDIO
+
+#if defined(_MSC_VER) && _MSC_VER >= 0x1400
+#define _CRT_SECURE_NO_WARNINGS // suppress bogus warnings about fopen()
+#endif
+
 #include <stdio.h>
 #endif
 
@@ -200,9 +211,15 @@ typedef unsigned char stbi_uc;
 extern "C" {
 #endif
 
+//////////////////////////////////////////////////////////////////////////////
+//
 // PRIMARY API - works on images of any type
+//
 
+//
 // load image by filename, open file, or memory buffer
+//
+
 extern stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
 
 #ifndef STBI_NO_STDIO
@@ -211,6 +228,15 @@ extern stbi_uc *stbi_load_from_file  (FILE *f,                  int *x, int *y, 
 // for stbi_load_from_file, file pointer is left pointing immediately after image
 #endif
 
+typedef struct
+{
+   int      (*read)  (void *user,char *data,int size);   // fill 'data' with 'size' bytes.  return number of bytes actually read 
+   void     (*skip)  (void *user,unsigned n);            // skip the next 'n' bytes
+   int      (*eof)   (void *user);                       // returns nonzero if we are at end of file/data
+} stbi_io_callbacks;
+
+extern stbi_uc *stbi_load_from_callbacks  (stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp);
+
 #ifndef STBI_NO_HDR
    extern float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
 
@@ -218,6 +244,8 @@ extern stbi_uc *stbi_load_from_file  (FILE *f,                  int *x, int *y, 
    extern float *stbi_loadf            (char const *filename,   int *x, int *y, int *comp, int req_comp);
    extern float *stbi_loadf_from_file  (FILE *f,                int *x, int *y, int *comp, int req_comp);
    #endif
+   
+   extern float *stbi_loadf_from_callbacks  (stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp);
 
    extern void   stbi_hdr_to_ldr_gamma(float gamma);
    extern void   stbi_hdr_to_ldr_scale(float scale);
@@ -225,6 +253,15 @@ extern stbi_uc *stbi_load_from_file  (FILE *f,                  int *x, int *y, 
    extern void   stbi_ldr_to_hdr_gamma(float gamma);
    extern void   stbi_ldr_to_hdr_scale(float scale);
 #endif // STBI_NO_HDR
+
+// stbi_is_hdr is always defined
+extern int    stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user);
+extern int    stbi_is_hdr_from_memory(stbi_uc const *buffer, int len);
+#ifndef STBI_NO_STDIO
+extern int      stbi_is_hdr          (char const *filename);
+extern int      stbi_is_hdr_from_file(FILE *f);
+#endif // STBI_NO_STDIO
+
 
 // get a VERY brief reason for failure
 // NOT THREADSAFE
@@ -235,15 +272,15 @@ extern void     stbi_image_free      (void *retval_from_stbi_load);
 
 // get image dimensions & components without fully decoding
 extern int      stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
-extern int      stbi_is_hdr_from_memory(stbi_uc const *buffer, int len);
+extern int      stbi_info_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp);
 
 #ifndef STBI_NO_STDIO
 extern int      stbi_info            (char const *filename,     int *x, int *y, int *comp);
 extern int      stbi_info_from_file  (FILE *f,                  int *x, int *y, int *comp);
 
-extern int      stbi_is_hdr          (char const *filename);
-extern int      stbi_is_hdr_from_file(FILE *f);
 #endif
+
+
 
 // for image formats that explicitly notate that they have premultiplied alpha,
 // we just return the colors as stored in the file. set this flag to force
@@ -264,21 +301,6 @@ extern int   stbi_zlib_decode_buffer(char *obuffer, int olen, const char *ibuffe
 extern char *stbi_zlib_decode_noheader_malloc(const char *buffer, int len, int *outlen);
 extern int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
 
-// define new loaders
-typedef struct
-{
-   int       (*test_memory)(stbi_uc const *buffer, int len);
-   stbi_uc * (*load_from_memory)(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-   #ifndef STBI_NO_STDIO
-   int       (*test_file)(FILE *f);
-   stbi_uc * (*load_from_file)(FILE *f, int *x, int *y, int *comp, int req_comp);
-   #endif
-} stbi_loader;
-
-// register a loader by filling out the above structure (you must define ALL functions)
-// returns 1 if added or already added, 0 if not added (too many loaders)
-// NOT THREADSAFE
-extern int stbi_register_loader(stbi_loader *loader);
 
 // define faster low-level operations (typically SIMD support)
 #ifdef STBI_SIMD
@@ -300,108 +322,6 @@ extern void stbi_install_YCbCr_to_RGB(stbi_YCbCr_to_RGB_run func);
 #endif // STBI_SIMD
 
 
-
-
-// TYPE-SPECIFIC ACCESS
-
-#ifdef STBI_TYPE_SPECIFIC_FUNCTIONS
-
-// is it a jpeg?
-extern int      stbi_jpeg_test_memory     (stbi_uc const *buffer, int len);
-extern stbi_uc *stbi_jpeg_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-extern int      stbi_jpeg_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
-
-#ifndef STBI_NO_STDIO
-extern stbi_uc *stbi_jpeg_load            (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern int      stbi_jpeg_test_file       (FILE *f);
-extern stbi_uc *stbi_jpeg_load_from_file  (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-
-extern int      stbi_jpeg_info            (char const *filename,     int *x, int *y, int *comp);
-extern int      stbi_jpeg_info_from_file  (FILE *f,                  int *x, int *y, int *comp);
-#endif
-
-// is it a png?
-extern int      stbi_png_test_memory      (stbi_uc const *buffer, int len);
-extern stbi_uc *stbi_png_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-extern int      stbi_png_info_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp);
-
-#ifndef STBI_NO_STDIO
-extern stbi_uc *stbi_png_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern int      stbi_png_info             (char const *filename,     int *x, int *y, int *comp);
-extern int      stbi_png_test_file        (FILE *f);
-extern stbi_uc *stbi_png_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-extern int      stbi_png_info_from_file   (FILE *f,                  int *x, int *y, int *comp);
-#endif
-
-// is it a bmp?
-extern int      stbi_bmp_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_bmp_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_bmp_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_bmp_test_file        (FILE *f);
-extern stbi_uc *stbi_bmp_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a tga?
-extern int      stbi_tga_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_tga_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_tga_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_tga_test_file        (FILE *f);
-extern stbi_uc *stbi_tga_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a psd?
-extern int      stbi_psd_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_psd_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_psd_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_psd_test_file        (FILE *f);
-extern stbi_uc *stbi_psd_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it an hdr?
-extern int      stbi_hdr_test_memory      (stbi_uc const *buffer, int len);
-
-extern float *  stbi_hdr_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern float *  stbi_hdr_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_hdr_test_file        (FILE *f);
-extern float *  stbi_hdr_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a pic?
-extern int      stbi_pic_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_pic_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_pic_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_pic_test_file        (FILE *f);
-extern stbi_uc *stbi_pic_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a gif?
-extern int      stbi_gif_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_gif_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_gif_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-extern int      stbi_gif_info_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp);
-
-#ifndef STBI_NO_STDIO
-extern int      stbi_gif_test_file        (FILE *f);
-extern stbi_uc *stbi_gif_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-extern int      stbi_gif_info             (char const *filename,     int *x, int *y, int *comp);
-extern int      stbi_gif_info_from_file   (FILE *f,                  int *x, int *y, int *comp);
-#endif
-
-#endif//STBI_TYPE_SPECIFIC_FUNCTIONS
-
-
-
-
 #ifdef __cplusplus
 }
 #endif
@@ -415,7 +335,7 @@ extern int      stbi_gif_info_from_file   (FILE *f,                  int *x, int
 
 #ifndef STBI_NO_HDR
 #include <math.h>  // ldexp
-#include <string.h> // strcmp
+#include <string.h> // strcmp, strtok
 #endif
 
 #ifndef STBI_NO_STDIO
@@ -427,16 +347,18 @@ extern int      stbi_gif_info_from_file   (FILE *f,                  int *x, int
 #include <stdarg.h>
 
 #ifndef _MSC_VER
-  #ifdef __cplusplus
-  #define __forceinline inline
-  #else
-  #define __forceinline
-  #endif
+   #ifdef __cplusplus
+   #define stbi_inline inline
+   #else
+   #define stbi_inline
+   #endif
+#else
+   #define stbi_inline __forceinline
 #endif
 
 
 // implementation:
-typedef unsigned char uint8;
+typedef unsigned char  uint8;
 typedef unsigned short uint16;
 typedef   signed short  int16;
 typedef unsigned int   uint32;
@@ -450,115 +372,124 @@ typedef unsigned char validate_uint32[sizeof(uint32)==4 ? 1 : -1];
 #define STBI_NO_WRITE
 #endif
 
-#define STBI_NOTUSED(v)  v=v
+#define STBI_NOTUSED(v)  (void)sizeof(v)
 
 #ifdef _MSC_VER
-#define STBI_HAS_LRTOL
+#define STBI_HAS_LROTL
 #endif
 
-#ifdef STBI_HAS_LRTOL
+#ifdef STBI_HAS_LROTL
    #define stbi_lrot(x,y)  _lrotl(x,y)
 #else
    #define stbi_lrot(x,y)  (((x) << (y)) | ((x) >> (32 - (y))))
 #endif
 
-//////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////
 //
-// Generic API that works on all image types
-//
+//  stbi struct and start_xxx functions
 
-// deprecated functions
+// stbi structure is our basic context used by all images, so it
+// contains all the IO context, plus some basic image information
+typedef struct
+{
+   uint32 img_x, img_y;
+   int img_n, img_out_n;
+   
+   stbi_io_callbacks io;
+   void *io_user_data;
 
-// is it a jpeg?
-extern int      stbi_jpeg_test_memory     (stbi_uc const *buffer, int len);
-extern stbi_uc *stbi_jpeg_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-extern int      stbi_jpeg_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
+   int read_from_callbacks;
+   int buflen;
+   uint8 buffer_start[128];
 
-#ifndef STBI_NO_STDIO
-extern stbi_uc *stbi_jpeg_load            (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern int      stbi_jpeg_test_file       (FILE *f);
-extern stbi_uc *stbi_jpeg_load_from_file  (FILE *f,                  int *x, int *y, int *comp, int req_comp);
+   uint8 *img_buffer, *img_buffer_end;
+   uint8 *img_buffer_original;
+} stbi;
 
-extern int      stbi_jpeg_info            (char const *filename,     int *x, int *y, int *comp);
-extern int      stbi_jpeg_info_from_file  (FILE *f,                  int *x, int *y, int *comp);
-#endif
 
-// is it a png?
-extern int      stbi_png_test_memory      (stbi_uc const *buffer, int len);
-extern stbi_uc *stbi_png_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-extern int      stbi_png_info_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp);
+static void refill_buffer(stbi *s);
 
-#ifndef STBI_NO_STDIO
-extern stbi_uc *stbi_png_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern int      stbi_png_info             (char const *filename,     int *x, int *y, int *comp);
-extern int      stbi_png_test_file        (FILE *f);
-extern stbi_uc *stbi_png_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-extern int      stbi_png_info_from_file   (FILE *f,                  int *x, int *y, int *comp);
-#endif
+// initialize a memory-decode context
+static void start_mem(stbi *s, uint8 const *buffer, int len)
+{
+   s->io.read = NULL;
+   s->read_from_callbacks = 0;
+   s->img_buffer = s->img_buffer_original = (uint8 *) buffer;
+   s->img_buffer_end = (uint8 *) buffer+len;
+}
 
-// is it a bmp?
-extern int      stbi_bmp_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_bmp_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_bmp_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_bmp_test_file        (FILE *f);
-extern stbi_uc *stbi_bmp_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a tga?
-extern int      stbi_tga_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_tga_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_tga_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_tga_test_file        (FILE *f);
-extern stbi_uc *stbi_tga_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a psd?
-extern int      stbi_psd_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_psd_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_psd_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_psd_test_file        (FILE *f);
-extern stbi_uc *stbi_psd_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it an hdr?
-extern int      stbi_hdr_test_memory      (stbi_uc const *buffer, int len);
-
-extern float *  stbi_hdr_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern float *  stbi_hdr_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_hdr_test_file        (FILE *f);
-extern float *  stbi_hdr_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a pic?
-extern int      stbi_pic_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_pic_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_pic_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-#ifndef STBI_NO_STDIO
-extern int      stbi_pic_test_file        (FILE *f);
-extern stbi_uc *stbi_pic_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-#endif
-
-// is it a gif?
-extern int      stbi_gif_test_memory      (stbi_uc const *buffer, int len);
-
-extern stbi_uc *stbi_gif_load             (char const *filename,     int *x, int *y, int *comp, int req_comp);
-extern stbi_uc *stbi_gif_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-extern int      stbi_gif_info_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp);
+// initialize a callback-based context
+static void start_callbacks(stbi *s, stbi_io_callbacks *c, void *user)
+{
+   s->io = *c;
+   s->io_user_data = user;
+   s->buflen = sizeof(s->buffer_start);
+   s->read_from_callbacks = 1;
+   s->img_buffer_original = s->buffer_start;
+   refill_buffer(s);
+}
 
 #ifndef STBI_NO_STDIO
-extern int      stbi_gif_test_file        (FILE *f);
-extern stbi_uc *stbi_gif_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp);
-extern int      stbi_gif_info             (char const *filename,     int *x, int *y, int *comp);
-extern int      stbi_gif_info_from_file   (FILE *f,                  int *x, int *y, int *comp);
-#endif
+
+static int stdio_read(void *user, char *data, int size)
+{
+   return (int) fread(data,1,size,(FILE*) user);
+}
+
+static void stdio_skip(void *user, unsigned n)
+{
+   fseek((FILE*) user, n, SEEK_CUR);
+}
+
+static int stdio_eof(void *user)
+{
+   return feof((FILE*) user);
+}
+
+static stbi_io_callbacks stbi_stdio_callbacks =
+{
+   stdio_read,
+   stdio_skip,
+   stdio_eof,
+};
+
+static void start_file(stbi *s, FILE *f)
+{
+   start_callbacks(s, &stbi_stdio_callbacks, (void *) f);
+}
+
+//static void stop_file(stbi *s) { }
+
+#endif // !STBI_NO_STDIO
+
+static void stbi_rewind(stbi *s)
+{
+   // conceptually rewind SHOULD rewind to the beginning of the stream,
+   // but we just rewind to the beginning of the initial buffer, because
+   // we only use it after doing 'test', which only ever looks at at most 92 bytes
+   s->img_buffer = s->img_buffer_original;
+}
+
+static int      stbi_jpeg_test(stbi *s);
+static stbi_uc *stbi_jpeg_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_jpeg_info(stbi *s, int *x, int *y, int *comp);
+static int      stbi_png_test(stbi *s);
+static stbi_uc *stbi_png_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_png_info(stbi *s, int *x, int *y, int *comp);
+static int      stbi_bmp_test(stbi *s);
+static stbi_uc *stbi_bmp_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_tga_test(stbi *s);
+static stbi_uc *stbi_tga_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_tga_info(stbi *s, int *x, int *y, int *comp);
+static int      stbi_psd_test(stbi *s);
+static stbi_uc *stbi_psd_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_hdr_test(stbi *s);
+static float   *stbi_hdr_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_pic_test(stbi *s);
+static stbi_uc *stbi_pic_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_gif_test(stbi *s);
+static stbi_uc *stbi_gif_load(stbi *s, int *x, int *y, int *comp, int req_comp);
+static int      stbi_gif_info(stbi *s, int *x, int *y, int *comp);
 
 
 // this is not threadsafe
@@ -574,6 +505,10 @@ static int e(const char *str)
    failure_reason = str;
    return 0;
 }
+
+// e - error
+// epf - error returning pointer to float
+// epuc - error returning pointer to unsigned char
 
 #ifdef STBI_NO_FAILURE_STRINGS
    #define e(x,y)  0
@@ -591,32 +526,32 @@ void stbi_image_free(void *retval_from_stbi_load)
    free(retval_from_stbi_load);
 }
 
-#define MAX_LOADERS  32
-stbi_loader *loaders[MAX_LOADERS];
-static int max_loaders = 0;
-
-int stbi_register_loader(stbi_loader *loader)
-{
-   int i;
-   for (i=0; i < MAX_LOADERS; ++i) {
-      // already present?
-      if (loaders[i] == loader)
-         return 1;
-      // end of the list?
-      if (loaders[i] == NULL) {
-         loaders[i] = loader;
-         max_loaders = i+1;
-         return 1;
-      }
-   }
-   // no room for it
-   return 0;
-}
-
 #ifndef STBI_NO_HDR
 static float   *ldr_to_hdr(stbi_uc *data, int x, int y, int comp);
 static stbi_uc *hdr_to_ldr(float   *data, int x, int y, int comp);
 #endif
+
+static unsigned char *stbi_load_main(stbi *s, int *x, int *y, int *comp, int req_comp)
+{
+   if (stbi_jpeg_test(s)) return stbi_jpeg_load(s,x,y,comp,req_comp);
+   if (stbi_png_test(s))  return stbi_png_load(s,x,y,comp,req_comp);
+   if (stbi_bmp_test(s))  return stbi_bmp_load(s,x,y,comp,req_comp);
+   if (stbi_gif_test(s))  return stbi_gif_load(s,x,y,comp,req_comp);
+   if (stbi_psd_test(s))  return stbi_psd_load(s,x,y,comp,req_comp);
+   if (stbi_pic_test(s))  return stbi_pic_load(s,x,y,comp,req_comp);
+
+   #ifndef STBI_NO_HDR
+   if (stbi_hdr_test(s)) {
+      float *hdr = stbi_hdr_load(s, x,y,comp,req_comp);
+      return hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
+   }
+   #endif
+
+   // test tga last because it's a crappy test!
+   if (stbi_tga_test(s))
+      return stbi_tga_load(s,x,y,comp,req_comp);
+   return epuc("unknown image type", "Image not of any known type, or corrupt");
+}
 
 #ifndef STBI_NO_STDIO
 unsigned char *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
@@ -631,58 +566,54 @@ unsigned char *stbi_load(char const *filename, int *x, int *y, int *comp, int re
 
 unsigned char *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
 {
-   int i;
-   if (stbi_jpeg_test_file(f)) return stbi_jpeg_load_from_file(f,x,y,comp,req_comp);
-   if (stbi_png_test_file(f))  return stbi_png_load_from_file(f,x,y,comp,req_comp);
-   if (stbi_bmp_test_file(f))  return stbi_bmp_load_from_file(f,x,y,comp,req_comp);
-   if (stbi_gif_test_file(f))  return stbi_gif_load_from_file(f,x,y,comp,req_comp);
-   if (stbi_psd_test_file(f))  return stbi_psd_load_from_file(f,x,y,comp,req_comp);
-   if (stbi_pic_test_file(f))  return stbi_pic_load_from_file(f,x,y,comp,req_comp);
-
-   #ifndef STBI_NO_HDR
-   if (stbi_hdr_test_file(f)) {
-      float *hdr = stbi_hdr_load_from_file(f, x,y,comp,req_comp);
-      return hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
-   }
-   #endif
-
-   for (i=0; i < max_loaders; ++i)
-      if (loaders[i]->test_file(f))
-         return loaders[i]->load_from_file(f,x,y,comp,req_comp);
-   // test tga last because it's a crappy test!
-   if (stbi_tga_test_file(f))
-      return stbi_tga_load_from_file(f,x,y,comp,req_comp);
-   return epuc("unknown image type", "Image not of any known type, or corrupt");
+   stbi s;
+   start_file(&s,f);
+   return stbi_load_main(&s,x,y,comp,req_comp);
 }
-#endif
+#endif //!STBI_NO_STDIO
 
 unsigned char *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
 {
-   int i;
-   if (stbi_jpeg_test_memory(buffer,len)) return stbi_jpeg_load_from_memory(buffer,len,x,y,comp,req_comp);
-   if (stbi_png_test_memory(buffer,len))  return stbi_png_load_from_memory(buffer,len,x,y,comp,req_comp);
-   if (stbi_bmp_test_memory(buffer,len))  return stbi_bmp_load_from_memory(buffer,len,x,y,comp,req_comp);
-   if (stbi_gif_test_memory(buffer,len))  return stbi_gif_load_from_memory(buffer,len,x,y,comp,req_comp);
-   if (stbi_psd_test_memory(buffer,len))  return stbi_psd_load_from_memory(buffer,len,x,y,comp,req_comp);
-   if (stbi_pic_test_memory(buffer,len))  return stbi_pic_load_from_memory(buffer,len,x,y,comp,req_comp);
+   stbi s;
+   start_mem(&s,buffer,len);
+   return stbi_load_main(&s,x,y,comp,req_comp);
+}
 
-   #ifndef STBI_NO_HDR
-   if (stbi_hdr_test_memory(buffer, len)) {
-      float *hdr = stbi_hdr_load_from_memory(buffer, len,x,y,comp,req_comp);
-      return hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
-   }
-   #endif
-
-   for (i=0; i < max_loaders; ++i)
-      if (loaders[i]->test_memory(buffer,len))
-         return loaders[i]->load_from_memory(buffer,len,x,y,comp,req_comp);
-   // test tga last because it's a crappy test!
-   if (stbi_tga_test_memory(buffer,len))
-      return stbi_tga_load_from_memory(buffer,len,x,y,comp,req_comp);
-   return epuc("unknown image type", "Image not of any known type, or corrupt");
+unsigned char *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
+{
+   stbi s;
+   start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi_load_main(&s,x,y,comp,req_comp);
 }
 
 #ifndef STBI_NO_HDR
+
+float *stbi_loadf_main(stbi *s, int *x, int *y, int *comp, int req_comp)
+{
+   unsigned char *data;
+   #ifndef STBI_NO_HDR
+   if (stbi_hdr_test(s))
+      return stbi_hdr_load(s,x,y,comp,req_comp);
+   #endif
+   data = stbi_load_main(s, x, y, comp, req_comp);
+   if (data)
+      return ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
+   return epf("unknown image type", "Image not of any known type, or corrupt");
+}
+
+float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
+{
+   stbi s;
+   start_mem(&s,buffer,len);
+   return stbi_loadf_main(&s,x,y,comp,req_comp);
+}
+
+float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
+{
+   stbi s;
+   start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi_loadf_main(&s,x,y,comp,req_comp);
+}
 
 #ifndef STBI_NO_STDIO
 float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
@@ -697,31 +628,13 @@ float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
 
 float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
 {
-   unsigned char *data;
-   #ifndef STBI_NO_HDR
-   if (stbi_hdr_test_file(f))
-      return stbi_hdr_load_from_file(f,x,y,comp,req_comp);
-   #endif
-   data = stbi_load_from_file(f, x, y, comp, req_comp);
-   if (data)
-      return ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
-   return epf("unknown image type", "Image not of any known type, or corrupt");
+   stbi s;
+   start_file(&s,f);
+   return stbi_loadf_main(&s,x,y,comp,req_comp);
 }
-#endif
+#endif // !STBI_NO_STDIO
 
-float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
-   stbi_uc *data;
-   #ifndef STBI_NO_HDR
-   if (stbi_hdr_test_memory(buffer, len))
-      return stbi_hdr_load_from_memory(buffer, len,x,y,comp,req_comp);
-   #endif
-   data = stbi_load_from_memory(buffer, len, x, y, comp, req_comp);
-   if (data)
-      return ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
-   return epf("unknown image type", "Image not of any known type, or corrupt");
-}
-#endif
+#endif // !STBI_NO_HDR
 
 // these is-hdr-or-not is defined independent of whether STBI_NO_HDR is
 // defined, for API simplicity; if STBI_NO_HDR is defined, it always
@@ -730,7 +643,9 @@ float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, in
 int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
 {
    #ifndef STBI_NO_HDR
-   return stbi_hdr_test_memory(buffer, len);
+   stbi s;
+   start_mem(&s,buffer,len);
+   return stbi_hdr_test(&s);
    #else
    STBI_NOTUSED(buffer);
    STBI_NOTUSED(len);
@@ -753,13 +668,25 @@ extern int      stbi_is_hdr          (char const *filename)
 extern int      stbi_is_hdr_from_file(FILE *f)
 {
    #ifndef STBI_NO_HDR
-   return stbi_hdr_test_file(f);
+   stbi s;
+   start_file(&s,f);
+   return stbi_hdr_test(&s);
    #else
    return 0;
    #endif
 }
+#endif // !STBI_NO_STDIO
 
-#endif
+extern int      stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user)
+{
+   #ifndef STBI_NO_HDR
+   stbi s;
+   start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi_hdr_test(&s);
+   #else
+   return 0;
+   #endif
+}
 
 #ifndef STBI_NO_HDR
 static float h2l_gamma_i=1.0f/2.2f, h2l_scale_i=1.0f;
@@ -785,47 +712,12 @@ enum
    SCAN_header
 };
 
-typedef struct
-{
-   uint32 img_x, img_y;
-   int img_n, img_out_n;
-
-   #ifndef STBI_NO_STDIO
-   FILE  *img_file;
-   int buflen;
-   uint8 buffer_start[128];
-   int from_file;
-   #endif
-   uint8 *img_buffer, *img_buffer_end;
-} stbi;
-
-#ifndef STBI_NO_STDIO
-static void start_file(stbi *s, FILE *f)
-{
-   s->img_file = f;
-   s->buflen = sizeof(s->buffer_start);
-   s->img_buffer_end = s->buffer_start + s->buflen;
-   s->img_buffer = s->img_buffer_end;
-   s->from_file = 1;
-}
-#endif
-
-static void start_mem(stbi *s, uint8 const *buffer, int len)
-{
-#ifndef STBI_NO_STDIO
-   s->img_file = NULL;
-   s->from_file = 0;
-#endif
-   s->img_buffer = (uint8 *) buffer;
-   s->img_buffer_end = (uint8 *) buffer+len;
-}
-
-#ifndef STBI_NO_STDIO
 static void refill_buffer(stbi *s)
 {
-   int n = fread(s->buffer_start, 1, s->buflen, s->img_file);
+   int n = (s->io.read)(s->io_user_data,(char*)s->buffer_start,s->buflen);
    if (n == 0) {
-      s->from_file = 0;
+      // at end of file, treat same as if from memory
+      s->read_from_callbacks = 0;
       s->img_buffer = s->img_buffer_end-1;
       *s->img_buffer = 0;
    } else {
@@ -833,68 +725,64 @@ static void refill_buffer(stbi *s)
       s->img_buffer_end = s->buffer_start + n;
    }
 }
-#endif
 
-__forceinline static int get8(stbi *s)
+stbi_inline static int get8(stbi *s)
 {
    if (s->img_buffer < s->img_buffer_end)
       return *s->img_buffer++;
-#ifndef STBI_NO_STDIO
-   if (s->from_file) {
+   if (s->read_from_callbacks) {
       refill_buffer(s);
       return *s->img_buffer++;
    }
-#endif
    return 0;
 }
 
-__forceinline static int at_eof(stbi *s)
+stbi_inline static int at_eof(stbi *s)
 {
-#ifndef STBI_NO_STDIO
-   if (s->img_file) {
-      if (!feof(s->img_file)) return 0;
+   if (s->io.read) {
+      if (!(s->io.eof)(s->io_user_data)) return 0;
       // if feof() is true, check if buffer = end
       // special case: we've only got the special 0 character at the end
-      if (s->from_file == 0) return 1;
+      if (s->read_from_callbacks == 0) return 1;
    }
-#endif
+
    return s->img_buffer >= s->img_buffer_end;   
 }
 
-__forceinline static uint8 get8u(stbi *s)
+stbi_inline static uint8 get8u(stbi *s)
 {
    return (uint8) get8(s);
 }
 
 static void skip(stbi *s, int n)
 {
-#ifndef STBI_NO_STDIO
-   if (s->img_file) {
+   if (s->io.read) {
       int blen = s->img_buffer_end - s->img_buffer;
       if (blen < n) {
          s->img_buffer = s->img_buffer_end;
-         fseek(s->img_file, n - blen, SEEK_CUR);
+         (s->io.skip)(s->io_user_data, n - blen);
          return;
       }
    }
-#endif
    s->img_buffer += n;
 }
 
 static int getn(stbi *s, stbi_uc *buffer, int n)
 {
-#ifndef STBI_NO_STDIO
-   if (s->img_file) {
+   if (s->io.read) {
       int blen = s->img_buffer_end - s->img_buffer;
       if (blen < n) {
-         int res;
+         int res, count;
+
          memcpy(buffer, s->img_buffer, blen);
-         res = ((int) fread(buffer + blen, 1, n - blen, s->img_file) == (n-blen));
+         
+         count = (s->io.read)(s->io_user_data, (char*) buffer + blen, n - blen);
+         res = (count == (n-blen));
          s->img_buffer = s->img_buffer_end;
          return res;
       }
    }
-#endif
+
    if (s->img_buffer+n <= s->img_buffer_end) {
       memcpy(buffer, s->img_buffer, n);
       s->img_buffer += n;
@@ -1078,7 +966,7 @@ typedef struct
    #ifdef STBI_SIMD
    unsigned short dequant2[4][64];
    #endif
-   stbi s;
+   stbi *s;
    huffman huff_dc[4];
    huffman huff_ac[4];
    uint8 dequant[4][64];
@@ -1156,9 +1044,9 @@ static int build_huffman(huffman *h, int *count)
 static void grow_buffer_unsafe(jpeg *j)
 {
    do {
-      int b = j->nomore ? 0 : get8(&j->s);
+      int b = j->nomore ? 0 : get8(j->s);
       if (b == 0xff) {
-         int c = get8(&j->s);
+         int c = get8(j->s);
          if (c != 0) {
             j->marker = (unsigned char) c;
             j->nomore = 1;
@@ -1174,7 +1062,7 @@ static void grow_buffer_unsafe(jpeg *j)
 static uint32 bmask[17]={0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535};
 
 // decode a jpeg huffman value from the bitstream
-__forceinline static int decode(jpeg *j, huffman *h)
+stbi_inline static int decode(jpeg *j, huffman *h)
 {
    unsigned int temp;
    int c,k;
@@ -1225,7 +1113,7 @@ __forceinline static int decode(jpeg *j, huffman *h)
 
 // combined JPEG 'receive' and JPEG 'extend', since baseline
 // always extends everything it receives.
-__forceinline static int extend_receive(jpeg *j, int n)
+stbi_inline static int extend_receive(jpeg *j, int n)
 {
    unsigned int m = 1 << (n-1);
    unsigned int k;
@@ -1303,7 +1191,7 @@ static int decode_block(jpeg *j, short data[64], huffman *hdc, huffman *hac, int
 }
 
 // take a -128..127 value and clamp it and convert to 0..255
-__forceinline static uint8 clamp(int x)
+stbi_inline static uint8 clamp(int x)
 {
    // trick to use a single test to catch both cases
    if ((unsigned int) x > 255) {
@@ -1425,7 +1313,7 @@ static void idct_block(uint8 *out, int out_stride, short data[64], stbi_dequanti
 #ifdef STBI_SIMD
 static stbi_idct_8x8 stbi_idct_installed = idct_block;
 
-extern void stbi_install_idct(stbi_idct_8x8 func)
+void stbi_install_idct(stbi_idct_8x8 func)
 {
    stbi_idct_installed = func;
 }
@@ -1439,10 +1327,10 @@ static uint8 get_marker(jpeg *j)
 {
    uint8 x;
    if (j->marker != MARKER_none) { x = j->marker; j->marker = MARKER_none; return x; }
-   x = get8u(&j->s);
+   x = get8u(j->s);
    if (x != 0xff) return MARKER_none;
    while (x == 0xff)
-      x = get8u(&j->s);
+      x = get8u(j->s);
    return x;
 }
 
@@ -1547,20 +1435,20 @@ static int process_marker(jpeg *z, int m)
          return e("progressive jpeg","JPEG format not supported (progressive)");
 
       case 0xDD: // DRI - specify restart interval
-         if (get16(&z->s) != 4) return e("bad DRI len","Corrupt JPEG");
-         z->restart_interval = get16(&z->s);
+         if (get16(z->s) != 4) return e("bad DRI len","Corrupt JPEG");
+         z->restart_interval = get16(z->s);
          return 1;
 
       case 0xDB: // DQT - define quantization table
-         L = get16(&z->s)-2;
+         L = get16(z->s)-2;
          while (L > 0) {
-            int q = get8(&z->s);
+            int q = get8(z->s);
             int p = q >> 4;
             int t = q & 15,i;
             if (p != 0) return e("bad DQT type","Corrupt JPEG");
             if (t > 3) return e("bad DQT table","Corrupt JPEG");
             for (i=0; i < 64; ++i)
-               z->dequant[t][dezigzag[i]] = get8u(&z->s);
+               z->dequant[t][dezigzag[i]] = get8u(z->s);
             #ifdef STBI_SIMD
             for (i=0; i < 64; ++i)
                z->dequant2[t][i] = z->dequant[t][i];
@@ -1570,16 +1458,16 @@ static int process_marker(jpeg *z, int m)
          return L==0;
 
       case 0xC4: // DHT - define huffman table
-         L = get16(&z->s)-2;
+         L = get16(z->s)-2;
          while (L > 0) {
             uint8 *v;
             int sizes[16],i,m=0;
-            int q = get8(&z->s);
+            int q = get8(z->s);
             int tc = q >> 4;
             int th = q & 15;
             if (tc > 1 || th > 3) return e("bad DHT header","Corrupt JPEG");
             for (i=0; i < 16; ++i) {
-               sizes[i] = get8(&z->s);
+               sizes[i] = get8(z->s);
                m += sizes[i];
             }
             L -= 17;
@@ -1591,14 +1479,14 @@ static int process_marker(jpeg *z, int m)
                v = z->huff_ac[th].values;
             }
             for (i=0; i < m; ++i)
-               v[i] = get8u(&z->s);
+               v[i] = get8u(z->s);
             L -= m;
          }
          return L==0;
    }
    // check for comment block or APP blocks
    if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE) {
-      skip(&z->s, get16(&z->s)-2);
+      skip(z->s, get16(z->s)-2);
       return 1;
    }
    return 0;
@@ -1608,31 +1496,31 @@ static int process_marker(jpeg *z, int m)
 static int process_scan_header(jpeg *z)
 {
    int i;
-   int Ls = get16(&z->s);
-   z->scan_n = get8(&z->s);
-   if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > (int) z->s.img_n) return e("bad SOS component count","Corrupt JPEG");
+   int Ls = get16(z->s);
+   z->scan_n = get8(z->s);
+   if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > (int) z->s->img_n) return e("bad SOS component count","Corrupt JPEG");
    if (Ls != 6+2*z->scan_n) return e("bad SOS len","Corrupt JPEG");
    for (i=0; i < z->scan_n; ++i) {
-      int id = get8(&z->s), which;
-      int q = get8(&z->s);
-      for (which = 0; which < z->s.img_n; ++which)
+      int id = get8(z->s), which;
+      int q = get8(z->s);
+      for (which = 0; which < z->s->img_n; ++which)
          if (z->img_comp[which].id == id)
             break;
-      if (which == z->s.img_n) return 0;
+      if (which == z->s->img_n) return 0;
       z->img_comp[which].hd = q >> 4;   if (z->img_comp[which].hd > 3) return e("bad DC huff","Corrupt JPEG");
       z->img_comp[which].ha = q & 15;   if (z->img_comp[which].ha > 3) return e("bad AC huff","Corrupt JPEG");
       z->order[i] = which;
    }
-   if (get8(&z->s) != 0) return e("bad SOS","Corrupt JPEG");
-   get8(&z->s); // should be 63, but might be 0
-   if (get8(&z->s) != 0) return e("bad SOS","Corrupt JPEG");
+   if (get8(z->s) != 0) return e("bad SOS","Corrupt JPEG");
+   get8(z->s); // should be 63, but might be 0
+   if (get8(z->s) != 0) return e("bad SOS","Corrupt JPEG");
 
    return 1;
 }
 
 static int process_frame_header(jpeg *z, int scan)
 {
-   stbi *s = &z->s;
+   stbi *s = z->s;
    int Lf,p,i,q, h_max=1,v_max=1,c;
    Lf = get16(s);         if (Lf < 11) return e("bad SOF len","Corrupt JPEG"); // JPEG
    p  = get8(s);          if (p != 8) return e("only 8-bit","JPEG format not supported: 8-bit only"); // JPEG baseline
@@ -1722,7 +1610,7 @@ static int decode_jpeg_header(jpeg *z, int scan)
       m = get_marker(z);
       while (m == MARKER_none) {
          // some files have extra padding after their blocks, so ok, we'll scan
-         if (at_eof(&z->s)) return e("no SOF", "Corrupt JPEG");
+         if (at_eof(z->s)) return e("no SOF", "Corrupt JPEG");
          m = get_marker(z);
       }
    }
@@ -1742,10 +1630,10 @@ static int decode_jpeg_image(jpeg *j)
          if (!parse_entropy_coded_data(j)) return 0;
          if (j->marker == MARKER_none ) {
             // handle 0s at the end of image data from IP Kamera 9060
-            while (!at_eof(&j->s)) {
-               int x = get8(&j->s);
+            while (!at_eof(j->s)) {
+               int x = get8(j->s);
                if (x == 255) {
-                  j->marker = get8u(&j->s);
+                  j->marker = get8u(j->s);
                   break;
                } else if (x != 0) {
                   return 0;
@@ -1895,7 +1783,7 @@ void stbi_install_YCbCr_to_RGB(stbi_YCbCr_to_RGB_run func)
 static void cleanup_jpeg(jpeg *j)
 {
    int i;
-   for (i=0; i < j->s.img_n; ++i) {
+   for (i=0; i < j->s->img_n; ++i) {
       if (j->img_comp[i].data) {
          free(j->img_comp[i].raw_data);
          j->img_comp[i].data = NULL;
@@ -1922,18 +1810,18 @@ static uint8 *load_jpeg_image(jpeg *z, int *out_x, int *out_y, int *comp, int re
    int n, decode_n;
    // validate req_comp
    if (req_comp < 0 || req_comp > 4) return epuc("bad req_comp", "Internal error");
-   z->s.img_n = 0;
+   z->s->img_n = 0;
 
    // load a jpeg image from whichever source
    if (!decode_jpeg_image(z)) { cleanup_jpeg(z); return NULL; }
 
    // determine actual number of components to generate
-   n = req_comp ? req_comp : z->s.img_n;
+   n = req_comp ? req_comp : z->s->img_n;
 
-   if (z->s.img_n == 3 && n < 3)
+   if (z->s->img_n == 3 && n < 3)
       decode_n = 1;
    else
-      decode_n = z->s.img_n;
+      decode_n = z->s->img_n;
 
    // resample and color-convert
    {
@@ -1949,13 +1837,13 @@ static uint8 *load_jpeg_image(jpeg *z, int *out_x, int *out_y, int *comp, int re
 
          // allocate line buffer big enough for upsampling off the edges
          // with upsample factor of 4
-         z->img_comp[k].linebuf = (uint8 *) malloc(z->s.img_x + 3);
+         z->img_comp[k].linebuf = (uint8 *) malloc(z->s->img_x + 3);
          if (!z->img_comp[k].linebuf) { cleanup_jpeg(z); return epuc("outofmem", "Out of memory"); }
 
          r->hs      = z->img_h_max / z->img_comp[k].h;
          r->vs      = z->img_v_max / z->img_comp[k].v;
          r->ystep   = r->vs >> 1;
-         r->w_lores = (z->s.img_x + r->hs-1) / r->hs;
+         r->w_lores = (z->s->img_x + r->hs-1) / r->hs;
          r->ypos    = 0;
          r->line0   = r->line1 = z->img_comp[k].data;
 
@@ -1967,12 +1855,12 @@ static uint8 *load_jpeg_image(jpeg *z, int *out_x, int *out_y, int *comp, int re
       }
 
       // can't error after this so, this is safe
-      output = (uint8 *) malloc(n * z->s.img_x * z->s.img_y + 1);
+      output = (uint8 *) malloc(n * z->s->img_x * z->s->img_y + 1);
       if (!output) { cleanup_jpeg(z); return epuc("outofmem", "Out of memory"); }
 
       // now go ahead and resample
-      for (j=0; j < z->s.img_y; ++j) {
-         uint8 *out = output + n * z->s.img_x * j;
+      for (j=0; j < z->s->img_y; ++j) {
+         uint8 *out = output + n * z->s->img_x * j;
          for (k=0; k < decode_n; ++k) {
             stbi_resample *r = &res_comp[k];
             int y_bot = r->ystep >= (r->vs >> 1);
@@ -1989,14 +1877,14 @@ static uint8 *load_jpeg_image(jpeg *z, int *out_x, int *out_y, int *comp, int re
          }
          if (n >= 3) {
             uint8 *y = coutput[0];
-            if (z->s.img_n == 3) {
+            if (z->s->img_n == 3) {
                #ifdef STBI_SIMD
                stbi_YCbCr_installed(out, y, coutput[1], coutput[2], z->s.img_x, n);
                #else
-               YCbCr_to_RGB_row(out, y, coutput[1], coutput[2], z->s.img_x, n);
+               YCbCr_to_RGB_row(out, y, coutput[1], coutput[2], z->s->img_x, n);
                #endif
             } else
-               for (i=0; i < z->s.img_x; ++i) {
+               for (i=0; i < z->s->img_x; ++i) {
                   out[0] = out[1] = out[2] = y[i];
                   out[3] = 255; // not used if n==3
                   out += n;
@@ -2004,117 +1892,54 @@ static uint8 *load_jpeg_image(jpeg *z, int *out_x, int *out_y, int *comp, int re
          } else {
             uint8 *y = coutput[0];
             if (n == 1)
-               for (i=0; i < z->s.img_x; ++i) out[i] = y[i];
+               for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
             else
-               for (i=0; i < z->s.img_x; ++i) *out++ = y[i], *out++ = 255;
+               for (i=0; i < z->s->img_x; ++i) *out++ = y[i], *out++ = 255;
          }
       }
       cleanup_jpeg(z);
-      *out_x = z->s.img_x;
-      *out_y = z->s.img_y;
-      if (comp) *comp  = z->s.img_n; // report original components, not output
+      *out_x = z->s->img_x;
+      *out_y = z->s->img_y;
+      if (comp) *comp  = z->s->img_n; // report original components, not output
       return output;
    }
 }
 
-#ifndef STBI_NO_STDIO
-unsigned char *stbi_jpeg_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
+static unsigned char *stbi_jpeg_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
    jpeg j;
-   start_file(&j.s, f);
+   j.s = s;
    return load_jpeg_image(&j, x,y,comp,req_comp);
 }
 
-unsigned char *stbi_jpeg_load(char const *filename, int *x, int *y, int *comp, int req_comp)
+static int stbi_jpeg_test(stbi *s)
 {
-   unsigned char *data;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return NULL;
-   data = stbi_jpeg_load_from_file(f,x,y,comp,req_comp);
-   fclose(f);
-   return data;
-}
-#endif
-
-unsigned char *stbi_jpeg_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
-   #ifdef STBI_SMALL_STACK
-   unsigned char *result;
-   jpeg *j = (jpeg *) malloc(sizeof(*j));
-   start_mem(&j->s, buffer, len);
-   result = load_jpeg_image(j,x,y,comp,req_comp);
-   free(j);
-   return result;
-   #else
+   int r;
    jpeg j;
-   start_mem(&j.s, buffer,len);
-   return load_jpeg_image(&j, x,y,comp,req_comp);
-   #endif
+   j.s = s;
+   r = decode_jpeg_header(&j, SCAN_type);
+   stbi_rewind(s);
+   return r;
 }
 
 static int stbi_jpeg_info_raw(jpeg *j, int *x, int *y, int *comp)
 {
-   if (!decode_jpeg_header(j, SCAN_header))
+   if (!decode_jpeg_header(j, SCAN_header)) {
+      stbi_rewind( j->s );
       return 0;
-   if (x) *x = j->s.img_x;
-   if (y) *y = j->s.img_y;
-   if (comp) *comp = j->s.img_n;
+   }
+   if (x) *x = j->s->img_x;
+   if (y) *y = j->s->img_y;
+   if (comp) *comp = j->s->img_n;
    return 1;
 }
 
-#ifndef STBI_NO_STDIO
-int stbi_jpeg_test_file(FILE *f)
-{
-   int n,r;
-   jpeg j;
-   n = ftell(f);
-   start_file(&j.s, f);
-   r = decode_jpeg_header(&j, SCAN_type);
-   fseek(f,n,SEEK_SET);
-   return r;
-}
-
-int stbi_jpeg_info_from_file(FILE *f, int *x, int *y, int *comp)
-{
-    jpeg j;
-    long n = ftell(f);
-    int res;
-    start_file(&j.s, f);
-    res = stbi_jpeg_info_raw(&j, x, y, comp);
-    fseek(f, n, SEEK_SET);
-    return res;
-}
-
-int stbi_jpeg_info(char const *filename, int *x, int *y, int *comp)
-{
-    FILE *f = fopen(filename, "rb");
-    int result;
-    if (!f) return e("can't fopen", "Unable to open file");
-    result = stbi_jpeg_info_from_file(f, x, y, comp);
-    fclose(f);
-    return result;
-}
-#endif
-
-int stbi_jpeg_test_memory(stbi_uc const *buffer, int len)
+static int stbi_jpeg_info(stbi *s, int *x, int *y, int *comp)
 {
    jpeg j;
-   start_mem(&j.s, buffer,len);
-   return decode_jpeg_header(&j, SCAN_type);
+   j.s = s;
+   return stbi_jpeg_info_raw(&j, x, y, comp);
 }
-
-int stbi_jpeg_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
-{
-    jpeg j;
-    start_mem(&j.s, buffer, len);
-    return stbi_jpeg_info_raw(&j, x, y, comp);
-}
-
-#ifndef STBI_NO_STDIO
-extern int      stbi_jpeg_info            (char const *filename,           int *x, int *y, int *comp);
-extern int      stbi_jpeg_info_from_file  (FILE *f,                  int *x, int *y, int *comp);
-#endif
-extern int      stbi_jpeg_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
 
 // public domain zlib decode    v0.2  Sean Barrett 2006-11-18
 //    simple implementation
@@ -2139,7 +1964,7 @@ typedef struct
    uint16 value[288]; 
 } zhuffman;
 
-__forceinline static int bitreverse16(int n)
+stbi_inline static int bitreverse16(int n)
 {
   n = ((n & 0xAAAA) >>  1) | ((n & 0x5555) << 1);
   n = ((n & 0xCCCC) >>  2) | ((n & 0x3333) << 2);
@@ -2148,7 +1973,7 @@ __forceinline static int bitreverse16(int n)
   return n;
 }
 
-__forceinline static int bit_reverse(int v, int bits)
+stbi_inline static int bit_reverse(int v, int bits)
 {
    assert(bits <= 16);
    // to bit reverse n bits, reverse 16 and shift
@@ -2221,7 +2046,7 @@ typedef struct
    zhuffman z_length, z_distance;
 } zbuf;
 
-__forceinline static int zget8(zbuf *z)
+stbi_inline static int zget8(zbuf *z)
 {
    if (z->zbuffer >= z->zbuffer_end) return 0;
    return *z->zbuffer++;
@@ -2236,7 +2061,7 @@ static void fill_bits(zbuf *z)
    } while (z->num_bits <= 24);
 }
 
-__forceinline static unsigned int zreceive(zbuf *z, int n)
+stbi_inline static unsigned int zreceive(zbuf *z, int n)
 {
    unsigned int k;
    if (z->num_bits < n) fill_bits(z);
@@ -2246,7 +2071,7 @@ __forceinline static unsigned int zreceive(zbuf *z, int n)
    return k;   
 }
 
-__forceinline static int zhuffman_decode(zbuf *a, zhuffman *z)
+stbi_inline static int zhuffman_decode(zbuf *a, zhuffman *z)
 {
    int b,s,k;
    if (a->num_bits < 16) fill_bits(a);
@@ -2582,13 +2407,13 @@ static int check_png_header(stbi *s)
    static uint8 png_sig[8] = { 137,80,78,71,13,10,26,10 };
    int i;
    for (i=0; i < 8; ++i)
-      if (get8(s) != png_sig[i]) return e("bad png sig","Not a PNG");
+      if (get8u(s) != png_sig[i]) return e("bad png sig","Not a PNG");
    return 1;
 }
 
 typedef struct
 {
-   stbi s;
+   stbi *s;
    uint8 *idata, *expanded, *out;
 } png;
 
@@ -2617,7 +2442,7 @@ static int paeth(int a, int b, int c)
 // create the png data from post-deflated data
 static int create_png_image_raw(png *a, uint8 *raw, uint32 raw_len, int out_n, uint32 x, uint32 y)
 {
-   stbi *s = &a->s;
+   stbi *s = a->s;
    uint32 i,j,stride = x*out_n;
    int k;
    int img_n = s->img_n; // copy it into a local for later
@@ -2698,12 +2523,12 @@ static int create_png_image(png *a, uint8 *raw, uint32 raw_len, int out_n, int i
    int p;
    int save;
    if (!interlaced)
-      return create_png_image_raw(a, raw, raw_len, out_n, a->s.img_x, a->s.img_y);
+      return create_png_image_raw(a, raw, raw_len, out_n, a->s->img_x, a->s->img_y);
    save = stbi_png_partial;
    stbi_png_partial = 0;
 
    // de-interlacing
-   final = (uint8 *) malloc(a->s.img_x * a->s.img_y * out_n);
+   final = (uint8 *) malloc(a->s->img_x * a->s->img_y * out_n);
    for (p=0; p < 7; ++p) {
       int xorig[] = { 0,4,0,2,0,1,0 };
       int yorig[] = { 0,0,4,0,2,0,1 };
@@ -2711,8 +2536,8 @@ static int create_png_image(png *a, uint8 *raw, uint32 raw_len, int out_n, int i
       int yspc[]  = { 8,8,8,4,4,2,2 };
       int i,j,x,y;
       // pass1_x[4] = 0, pass1_x[5] = 1, pass1_x[12] = 1
-      x = (a->s.img_x - xorig[p] + xspc[p]-1) / xspc[p];
-      y = (a->s.img_y - yorig[p] + yspc[p]-1) / yspc[p];
+      x = (a->s->img_x - xorig[p] + xspc[p]-1) / xspc[p];
+      y = (a->s->img_y - yorig[p] + yspc[p]-1) / yspc[p];
       if (x && y) {
          if (!create_png_image_raw(a, raw, raw_len, out_n, x, y)) {
             free(final);
@@ -2720,7 +2545,7 @@ static int create_png_image(png *a, uint8 *raw, uint32 raw_len, int out_n, int i
          }
          for (j=0; j < y; ++j)
             for (i=0; i < x; ++i)
-               memcpy(final + (j*yspc[p]+yorig[p])*a->s.img_x*out_n + (i*xspc[p]+xorig[p])*out_n,
+               memcpy(final + (j*yspc[p]+yorig[p])*a->s->img_x*out_n + (i*xspc[p]+xorig[p])*out_n,
                       a->out + (j*x+i)*out_n, out_n);
          free(a->out);
          raw += (x*out_n+1)*y;
@@ -2735,7 +2560,7 @@ static int create_png_image(png *a, uint8 *raw, uint32 raw_len, int out_n, int i
 
 static int compute_transparency(png *z, uint8 tc[3], int out_n)
 {
-   stbi *s = &z->s;
+   stbi *s = z->s;
    uint32 i, pixel_count = s->img_x * s->img_y;
    uint8 *p = z->out;
 
@@ -2760,7 +2585,7 @@ static int compute_transparency(png *z, uint8 tc[3], int out_n)
 
 static int expand_palette(png *a, uint8 *palette, int len, int pal_img_n)
 {
-   uint32 i, pixel_count = a->s.img_x * a->s.img_y;
+   uint32 i, pixel_count = a->s->img_x * a->s->img_y;
    uint8 *p, *temp_out, *orig = a->out;
 
    p = (uint8 *) malloc(pixel_count * pal_img_n);
@@ -2809,7 +2634,7 @@ void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert)
 
 static void stbi_de_iphone(png *z)
 {
-   stbi *s = &z->s;
+   stbi *s = z->s;
    uint32 i, pixel_count = s->img_x * s->img_y;
    uint8 *p = z->out;
 
@@ -2855,7 +2680,11 @@ static int parse_png_file(png *z, int scan, int req_comp)
    uint8 has_trans=0, tc[3];
    uint32 ioff=0, idata_limit=0, i, pal_len=0;
    int first=1,k,interlace=0, iphone=0;
-   stbi *s = &z->s;
+   stbi *s = z->s;
+
+   z->expanded = NULL;
+   z->idata = NULL;
+   z->out = NULL;
 
    if (!check_png_header(s)) return 0;
 
@@ -3001,21 +2830,18 @@ static int parse_png_file(png *z, int scan, int req_comp)
 static unsigned char *do_png(png *p, int *x, int *y, int *n, int req_comp)
 {
    unsigned char *result=NULL;
-   p->expanded = NULL;
-   p->idata = NULL;
-   p->out = NULL;
    if (req_comp < 0 || req_comp > 4) return epuc("bad req_comp", "Internal error");
    if (parse_png_file(p, SCAN_load, req_comp)) {
       result = p->out;
       p->out = NULL;
-      if (req_comp && req_comp != p->s.img_out_n) {
-         result = convert_format(result, p->s.img_out_n, req_comp, p->s.img_x, p->s.img_y);
-         p->s.img_out_n = req_comp;
+      if (req_comp && req_comp != p->s->img_out_n) {
+         result = convert_format(result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         p->s->img_out_n = req_comp;
          if (result == NULL) return result;
       }
-      *x = p->s.img_x;
-      *y = p->s.img_y;
-      if (n) *n = p->s.img_n;
+      *x = p->s->img_x;
+      *y = p->s->img_y;
+      if (n) *n = p->s->img_n;
    }
    free(p->out);      p->out      = NULL;
    free(p->expanded); p->expanded = NULL;
@@ -3024,89 +2850,37 @@ static unsigned char *do_png(png *p, int *x, int *y, int *n, int req_comp)
    return result;
 }
 
-#ifndef STBI_NO_STDIO
-unsigned char *stbi_png_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
+static unsigned char *stbi_png_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
    png p;
-   start_file(&p.s, f);
+   p.s = s;
    return do_png(&p, x,y,comp,req_comp);
 }
 
-unsigned char *stbi_png_load(char const *filename, int *x, int *y, int *comp, int req_comp)
+static int stbi_png_test(stbi *s)
 {
-   unsigned char *data;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return NULL;
-   data = stbi_png_load_from_file(f,x,y,comp,req_comp);
-   fclose(f);
-   return data;
-}
-#endif
-
-unsigned char *stbi_png_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
-   png p;
-   start_mem(&p.s, buffer,len);
-   return do_png(&p, x,y,comp,req_comp);
-}
-
-#ifndef STBI_NO_STDIO
-int stbi_png_test_file(FILE *f)
-{
-   png p;
-   int n,r;
-   n = ftell(f);
-   start_file(&p.s, f);
-   r = parse_png_file(&p, SCAN_type,STBI_default);
-   fseek(f,n,SEEK_SET);
+   int r;
+   r = check_png_header(s);
+   stbi_rewind(s);
    return r;
-}
-#endif
-
-int stbi_png_test_memory(stbi_uc const *buffer, int len)
-{
-   png p;
-   start_mem(&p.s, buffer, len);
-   return parse_png_file(&p, SCAN_type,STBI_default);
 }
 
 static int stbi_png_info_raw(png *p, int *x, int *y, int *comp)
 {
-   if (!parse_png_file(p, SCAN_header, 0))
+   if (!parse_png_file(p, SCAN_header, 0)) {
+      stbi_rewind( p->s );
       return 0;
-   if (x) *x = p->s.img_x;
-   if (y) *y = p->s.img_y;
-   if (comp) *comp = p->s.img_n;
+   }
+   if (x) *x = p->s->img_x;
+   if (y) *y = p->s->img_y;
+   if (comp) *comp = p->s->img_n;
    return 1;
 }
 
-#ifndef STBI_NO_STDIO
-int      stbi_png_info             (char const *filename,           int *x, int *y, int *comp)
-{
-   int res;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return 0;
-   res = stbi_png_info_from_file(f, x, y, comp);
-   fclose(f);
-   return res;
-}
-
-int stbi_png_info_from_file(FILE *f, int *x, int *y, int *comp)
+static int      stbi_png_info(stbi *s, int *x, int *y, int *comp)
 {
    png p;
-   int res;
-   long n = ftell(f);
-   start_file(&p.s, f);
-   res = stbi_png_info_raw(&p, x, y, comp);
-   fseek(f, n, SEEK_SET);
-   return res;
-}
-#endif // !STBI_NO_STDIO
-
-int stbi_png_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
-{
-   png p;
-   start_mem(&p.s, buffer, len);
+   p.s = s;
    return stbi_png_info_raw(&p, x, y, comp);
 }
 
@@ -3126,24 +2900,13 @@ static int bmp_test(stbi *s)
    return 0;
 }
 
-#ifndef STBI_NO_STDIO
-int      stbi_bmp_test_file        (FILE *f)
+static int stbi_bmp_test(stbi *s)
 {
-   stbi s;
-   int r,n = ftell(f);
-   start_file(&s,f);
-   r = bmp_test(&s);
-   fseek(f,n,SEEK_SET);
+   int r = bmp_test(s);
+   stbi_rewind(s);
    return r;
 }
-#endif
 
-int      stbi_bmp_test_memory      (stbi_uc const *buffer, int len)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return bmp_test(&s);
-}
 
 // returns 0..31 for the highest set bit
 static int high_bit(unsigned int z)
@@ -3322,11 +3085,11 @@ static stbi_uc *bmp_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       if (bpp == 24) {
          easy = 1;
       } else if (bpp == 32) {
-         if (mb == 0xff && mg == 0xff00 && mr == 0xff000000 && ma == 0xff000000)
+         if (mb == 0xff && mg == 0xff00 && mr == 0x00ff0000 && ma == 0xff000000)
             easy = 2;
       }
       if (!easy) {
-         if (!mr || !mg || !mb) return epuc("bad masks", "Corrupt BMP");
+         if (!mr || !mg || !mb) { free(out); return epuc("bad masks", "Corrupt BMP"); }
          // right shift amt to put high bit in position #7
          rshift = high_bit(mr)-7; rcount = bitcount(mr);
          gshift = high_bit(mg)-7; gcount = bitcount(mr);
@@ -3376,35 +3139,15 @@ static stbi_uc *bmp_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 
    *x = s->img_x;
    *y = s->img_y;
-   if (comp) *comp = target;
+   if (comp) *comp = s->img_n;
    return out;
 }
 
-#ifndef STBI_NO_STDIO
-stbi_uc *stbi_bmp_load             (char const *filename,           int *x, int *y, int *comp, int req_comp)
+static stbi_uc *stbi_bmp_load(stbi *s,int *x, int *y, int *comp, int req_comp)
 {
-   stbi_uc *data;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return NULL;
-   data = stbi_bmp_load_from_file(f, x,y,comp,req_comp);
-   fclose(f);
-   return data;
+   return bmp_load(s, x,y,comp,req_comp);
 }
 
-stbi_uc *stbi_bmp_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_file(&s, f);
-   return bmp_load(&s, x,y,comp,req_comp);
-}
-#endif
-
-stbi_uc *stbi_bmp_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return bmp_load(&s, x,y,comp,req_comp);
-}
 
 // Targa Truevision - TGA
 // by Jonathan Dummer
@@ -3415,22 +3158,30 @@ static int tga_info(stbi *s, int *x, int *y, int *comp)
     int sz;
     get8u(s);                   // discard Offset
     sz = get8u(s);              // color type
-    if( sz > 1 ) return 0;      // only RGB or indexed allowed
+    if( sz > 1 ) {
+        stbi_rewind(s);
+        return 0;      // only RGB or indexed allowed
+    }
     sz = get8u(s);              // image type
     // only RGB or grey allowed, +/- RLE
     if ((sz != 1) && (sz != 2) && (sz != 3) && (sz != 9) && (sz != 10) && (sz != 11)) return 0;
-    get16le(s);                 // discard palette start
-    get16le(s);                 // discard palette length
-    get8(s);                    // discard bits per palette color entry
-    get16le(s);                 // discard x origin
-    get16le(s);                 // discard y origin
+    skip(s,9);
     tga_w = get16le(s);
-    if( tga_w < 1 ) return 0;   // test width
+    if( tga_w < 1 ) {
+        stbi_rewind(s);
+        return 0;   // test width
+    }
     tga_h = get16le(s);
-    if( tga_h < 1 ) return 0;   // test height
+    if( tga_h < 1 ) {
+        stbi_rewind(s);
+        return 0;   // test height
+    }
     sz = get8(s);               // bits per pixel
     // only RGB or RGBA or grey allowed
-    if ((sz != 8) && (sz != 16) && (sz != 24) && (sz != 32)) return 0;
+    if ((sz != 8) && (sz != 16) && (sz != 24) && (sz != 32)) {
+        stbi_rewind(s);
+        return 0;
+    }
     tga_comp = sz;
     if (x) *x = tga_w;
     if (y) *y = tga_h;
@@ -3438,24 +3189,9 @@ static int tga_info(stbi *s, int *x, int *y, int *comp)
     return 1;                   // seems to have passed everything
 }
 
-#ifndef STBI_NO_STDIO
-int stbi_tga_info_from_file(FILE *f, int *x, int *y, int *comp)
+int stbi_tga_info(stbi *s, int *x, int *y, int *comp)
 {
-    stbi s;
-    int r;
-    long n = ftell(f);
-    start_file(&s, f);
-    r = tga_info(&s, x, y, comp);
-    fseek(f, n, SEEK_SET);
-    return r;
-}
-#endif
-
-int stbi_tga_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
-{
-    stbi s;
-    start_mem(&s, buffer, len);
-    return tga_info(&s, x, y, comp);
+    return tga_info(s, x, y, comp);
 }
 
 static int tga_test(stbi *s)
@@ -3478,23 +3214,11 @@ static int tga_test(stbi *s)
    return 1;      //   seems to have passed everything
 }
 
-#ifndef STBI_NO_STDIO
-int      stbi_tga_test_file        (FILE *f)
+static int stbi_tga_test(stbi *s)
 {
-   stbi s;
-   int r,n = ftell(f);
-   start_file(&s, f);
-   r = tga_test(&s);
-   fseek(f,n,SEEK_SET);
-   return r;
-}
-#endif
-
-int      stbi_tga_test_memory      (stbi_uc const *buffer, int len)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return tga_test(&s);
+   int res = tga_test(s);
+   stbi_rewind(s);
+   return res;
 }
 
 static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
@@ -3540,7 +3264,7 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       (tga_bits_per_pixel != 24) && (tga_bits_per_pixel != 32))
       )
    {
-      return NULL;
+      return NULL; // we don't report this as a bad TGA because we don't even know if it's TGA
    }
 
    //   If I'm paletted, then I'll use the number of bits from the palette
@@ -3563,6 +3287,7 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       *comp = tga_bits_per_pixel/8;
    }
    tga_data = (unsigned char*)malloc( tga_width * tga_height * req_comp );
+   if (!tga_data) return epuc("outofmem", "Out of memory");
 
    //   skip to the data's starting position (offset usually = 0)
    skip(s, tga_offset );
@@ -3573,8 +3298,12 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       skip(s, tga_palette_start );
       //   load the palette
       tga_palette = (unsigned char*)malloc( tga_palette_len * tga_palette_bits / 8 );
-      if (!getn(s, tga_palette, tga_palette_len * tga_palette_bits / 8 ))
-         return NULL;
+      if (!tga_palette) return epuc("outofmem", "Out of memory");
+      if (!getn(s, tga_palette, tga_palette_len * tga_palette_bits / 8 )) {
+         free(tga_data);
+         free(tga_palette);
+         return epuc("bad palette", "Corrupt TGA");
+      }
    }
    //   load the data
    trans_data[0] = trans_data[1] = trans_data[2] = trans_data[3] = 0;
@@ -3718,30 +3447,9 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
    return tga_data;
 }
 
-#ifndef STBI_NO_STDIO
-stbi_uc *stbi_tga_load             (char const *filename,           int *x, int *y, int *comp, int req_comp)
+static stbi_uc *stbi_tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
-   stbi_uc *data;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return NULL;
-   data = stbi_tga_load_from_file(f, x,y,comp,req_comp);
-   fclose(f);
-   return data;
-}
-
-stbi_uc *stbi_tga_load_from_file   (FILE *f,                  int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_file(&s, f);
-   return tga_load(&s, x,y,comp,req_comp);
-}
-#endif
-
-stbi_uc *stbi_tga_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return tga_load(&s, x,y,comp,req_comp);
+   return tga_load(s,x,y,comp,req_comp);
 }
 
 
@@ -3754,23 +3462,11 @@ static int psd_test(stbi *s)
    else return 1;
 }
 
-#ifndef STBI_NO_STDIO
-int stbi_psd_test_file(FILE *f)
+static int stbi_psd_test(stbi *s)
 {
-   stbi s;
-   int r,n = ftell(f);
-   start_file(&s, f);
-   r = psd_test(&s);
-   fseek(f,n,SEEK_SET);
+   int r = psd_test(s);
+   stbi_rewind(s);
    return r;
-}
-#endif
-
-int stbi_psd_test_memory(stbi_uc const *buffer, int len)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return psd_test(&s);
 }
 
 static stbi_uc *psd_load(stbi *s, int *x, int *y, int *comp, int req_comp)
@@ -3931,30 +3627,9 @@ static stbi_uc *psd_load(stbi *s, int *x, int *y, int *comp, int req_comp)
    return out;
 }
 
-#ifndef STBI_NO_STDIO
-stbi_uc *stbi_psd_load(char const *filename, int *x, int *y, int *comp, int req_comp)
+static stbi_uc *stbi_psd_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
-   stbi_uc *data;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return NULL;
-   data = stbi_psd_load_from_file(f, x,y,comp,req_comp);
-   fclose(f);
-   return data;
-}
-
-stbi_uc *stbi_psd_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_file(&s, f);
-   return psd_load(&s, x,y,comp,req_comp);
-}
-#endif
-
-stbi_uc *stbi_psd_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return psd_load(&s, x,y,comp,req_comp);
+   return psd_load(s,x,y,comp,req_comp);
 }
 
 // *************************************************************************************************
@@ -4162,49 +3837,17 @@ static stbi_uc *pic_load(stbi *s,int *px,int *py,int *comp,int req_comp)
    return result;
 }
 
-int stbi_pic_test_memory(stbi_uc const *buffer, int len)
+static int stbi_pic_test(stbi *s)
 {
-   stbi s;
-   start_mem(&s,buffer,len);
-   return pic_test(&s);
+   int r = pic_test(s);
+   stbi_rewind(s);
+   return r;
 }
 
-stbi_uc *stbi_pic_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
+static stbi_uc *stbi_pic_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
-   stbi s;
-   start_mem(&s,buffer,len);
-   return pic_load(&s,x,y,comp,req_comp);
+   return pic_load(s,x,y,comp,req_comp);
 }
-
-#ifndef STBI_NO_STDIO
-int stbi_pic_test_file(FILE *f)
-{
-   int result;
-   long l = ftell(f);
-   stbi s;
-   start_file(&s,f);
-   result = pic_test(&s);
-   fseek(f,l,SEEK_SET);
-   return result;
-}
-
-stbi_uc *stbi_pic_load(char const *filename,int *x, int *y, int *comp, int req_comp)
-{
-   stbi_uc *result;
-   FILE *f=fopen(filename,"rb");
-   if (!f) return 0;
-   result = stbi_pic_load_from_file(f,x,y,comp,req_comp);
-   fclose(f);
-   return result;
-}
-
-stbi_uc *stbi_pic_load_from_file(FILE *f,int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_file(&s,f);
-   return pic_load(&s,x,y,comp,req_comp);
-}
-#endif
 
 // *************************************************************************************************
 // GIF loader -- public domain by Jean-Marc Lienher -- simplified/shrunk by stb
@@ -4241,23 +3884,11 @@ static int gif_test(stbi *s)
    return 1;
 }
 
-#ifndef STBI_NO_STDIO
-int      stbi_gif_test_file        (FILE *f)
+static int stbi_gif_test(stbi *s)
 {
-   stbi s;
-   int r,n = ftell(f);
-   start_file(&s,f);
-   r = gif_test(&s);
-   fseek(f,n,SEEK_SET);
+   int r = gif_test(s);
+   stbi_rewind(s);
    return r;
-}
-#endif
-
-int      stbi_gif_test_memory      (stbi_uc const *buffer, int len)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return gif_test(&s);
 }
 
 static void stbi_gif_parse_colortable(stbi *s, uint8 pal[256][4], int num_entries, int transp)
@@ -4302,7 +3933,10 @@ static int stbi_gif_header(stbi *s, stbi_gif *g, int *comp, int is_info)
 static int stbi_gif_info_raw(stbi *s, int *x, int *y, int *comp)
 {
    stbi_gif g;   
-   if (!stbi_gif_header(s, &g, comp, 1)) return 0;
+   if (!stbi_gif_header(s, &g, comp, 1)) {
+      stbi_rewind( s );
+      return 0;
+   }
    if (x) *x = g.w;
    if (y) *y = g.h;
    return 1;
@@ -4536,25 +4170,12 @@ static uint8 *stbi_gif_load_next(stbi *s, stbi_gif *g, int *comp, int req_comp)
    }
 }
 
-#ifndef STBI_NO_STDIO
-stbi_uc *stbi_gif_load             (char const *filename,           int *x, int *y, int *comp, int req_comp)
-{
-   uint8 *data;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return NULL;
-   data = stbi_gif_load_from_file(f, x,y,comp,req_comp);
-   fclose(f);
-   return data;
-}
-
-stbi_uc *stbi_gif_load_from_file   (FILE *f, int *x, int *y, int *comp, int req_comp)
+static stbi_uc *stbi_gif_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
    uint8 *u = 0;
-   stbi s;
    stbi_gif g={0};
-   start_file(&s, f);
 
-   u = stbi_gif_load_next(&s, &g, comp, req_comp);
+   u = stbi_gif_load_next(s, &g, comp, req_comp);
    if (u == (void *) 1) u = 0;  // end of animated gif marker
    if (u) {
       *x = g.w;
@@ -4563,54 +4184,11 @@ stbi_uc *stbi_gif_load_from_file   (FILE *f, int *x, int *y, int *comp, int req_
 
    return u;
 }
-#endif
 
-stbi_uc *stbi_gif_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
+static int stbi_gif_info(stbi *s, int *x, int *y, int *comp)
 {
-   uint8 *u = 0;
-   stbi s;
-   stbi_gif g={0};
-   start_mem(&s, buffer, len);
-   u = stbi_gif_load_next(&s, &g, comp, req_comp);
-   if (u == (void *) 1) u = 0;  // end of animated gif marker
-   if (u) {
-      *x = g.w;
-      *y = g.h;
-   }
-   return u;
+   return stbi_gif_info_raw(s,x,y,comp);
 }
-
-#ifndef STBI_NO_STDIO
-int      stbi_gif_info             (char const *filename,           int *x, int *y, int *comp)
-{
-   int res;
-   FILE *f = fopen(filename, "rb");
-   if (!f) return 0;
-   res = stbi_gif_info_from_file(f, x, y, comp);
-   fclose(f);
-   return res;
-}
-
-int stbi_gif_info_from_file(FILE *f, int *x, int *y, int *comp)
-{
-   stbi s;
-   int res;
-   long n = ftell(f);
-   start_file(&s, f);
-   res = stbi_gif_info_raw(&s, x, y, comp);
-   fseek(f, n, SEEK_SET);
-   return res;
-}
-#endif // !STBI_NO_STDIO
-
-int stbi_gif_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
-{
-   stbi s;
-   start_mem(&s, buffer, len);
-   return stbi_gif_info_raw(&s, x, y, comp);
-}
-
-
 
 
 // *************************************************************************************************
@@ -4627,24 +4205,12 @@ static int hdr_test(stbi *s)
    return 1;
 }
 
-int stbi_hdr_test_memory(stbi_uc const *buffer, int len)
+static int stbi_hdr_test(stbi* s)
 {
-   stbi s;
-   start_mem(&s, buffer, len);
-   return hdr_test(&s);
-}
-
-#ifndef STBI_NO_STDIO
-int stbi_hdr_test_file(FILE *f)
-{
-   stbi s;
-   int r,n = ftell(f);
-   start_file(&s, f);
-   r = hdr_test(&s);
-   fseek(f,n,SEEK_SET);
+   int r = hdr_test(s);
+   stbi_rewind(s);
    return r;
 }
-#endif
 
 #define HDR_BUFLEN  1024
 static char *hdr_gettoken(stbi *z, char *buffer)
@@ -4695,7 +4261,6 @@ static void hdr_convert(float *output, stbi_uc *input, int req_comp)
       }
    }
 }
-
 
 static float *hdr_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
@@ -4808,24 +4373,178 @@ static float *hdr_load(stbi *s, int *x, int *y, int *comp, int req_comp)
    return hdr_data;
 }
 
-#ifndef STBI_NO_STDIO
-float *stbi_hdr_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
+static float *stbi_hdr_load(stbi *s, int *x, int *y, int *comp, int req_comp)
 {
-   stbi s;
-   start_file(&s,f);
-   return hdr_load(&s,x,y,comp,req_comp);
-}
-#endif
-
-float *stbi_hdr_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
-   stbi s;
-   start_mem(&s,buffer, len);
-   return hdr_load(&s,x,y,comp,req_comp);
+   return hdr_load(s,x,y,comp,req_comp);
 }
 
+static int stbi_hdr_info(stbi *s, int *x, int *y, int *comp)
+{
+   char buffer[HDR_BUFLEN];
+   char *token;
+   int valid = 0;
+
+   if (strcmp(hdr_gettoken(s,buffer), "#?RADIANCE") != 0) {
+       stbi_rewind( s );
+       return 0;
+   }
+
+   for(;;) {
+      token = hdr_gettoken(s,buffer);
+      if (token[0] == 0) break;
+      if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
+   }
+
+   if (!valid) {
+       stbi_rewind( s );
+       return 0;
+   }
+   token = hdr_gettoken(s,buffer);
+   if (strncmp(token, "-Y ", 3)) {
+       stbi_rewind( s );
+       return 0;
+   }
+   token += 3;
+   *y = strtol(token, &token, 10);
+   while (*token == ' ') ++token;
+   if (strncmp(token, "+X ", 3)) {
+       stbi_rewind( s );
+       return 0;
+   }
+   token += 3;
+   *x = strtol(token, NULL, 10);
+   *comp = 3;
+   return 1;
+}
 #endif // STBI_NO_HDR
 
+static int stbi_bmp_info(stbi *s, int *x, int *y, int *comp)
+{
+   int hsz;
+   if (get8(s) != 'B' || get8(s) != 'M') {
+       stbi_rewind( s );
+       return 0;
+   }
+   skip(s,12);
+   hsz = get32le(s);
+   if (hsz != 12 && hsz != 40 && hsz != 56 && hsz != 108) {
+       stbi_rewind( s );
+       return 0;
+   }
+   if (hsz == 12) {
+      *x = get16le(s);
+      *y = get16le(s);
+   } else {
+      *x = get32le(s);
+      *y = get32le(s);
+   }
+   if (get16le(s) != 1) {
+       stbi_rewind( s );
+       return 0;
+   }
+   *comp = get16le(s) / 8;
+   return 1;
+}
+
+static int stbi_psd_info(stbi *s, int *x, int *y, int *comp)
+{
+   int channelCount;
+   if (get32(s) != 0x38425053) {
+       stbi_rewind( s );
+       return 0;
+   }
+   if (get16(s) != 1) {
+       stbi_rewind( s );
+       return 0;
+   }
+   skip(s, 6);
+   channelCount = get16(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi_rewind( s );
+       return 0;
+   }
+   *y = get32(s);
+   *x = get32(s);
+   if (get16(s) != 8) {
+       stbi_rewind( s );
+       return 0;
+   }
+   if (get16(s) != 3) {
+       stbi_rewind( s );
+       return 0;
+   }
+   *comp = 4;
+   return 1;
+}
+
+static int stbi_pic_info(stbi *s, int *x, int *y, int *comp)
+{
+   int act_comp=0,num_packets=0,chained;
+   pic_packet_t packets[10];
+
+   skip(s, 92);
+
+   *x = get16(s);
+   *y = get16(s);
+   if (at_eof(s))  return 0;
+   if ( (*x) != 0 && (1 << 28) / (*x) < (*y)) {
+       stbi_rewind( s );
+       return 0;
+   }
+
+   skip(s, 8);
+
+   do {
+      pic_packet_t *packet;
+
+      if (num_packets==sizeof(packets)/sizeof(packets[0]))
+         return 0;
+
+      packet = &packets[num_packets++];
+      chained = get8(s);
+      packet->size    = get8u(s);
+      packet->type    = get8u(s);
+      packet->channel = get8u(s);
+      act_comp |= packet->channel;
+
+      if (at_eof(s)) {
+          stbi_rewind( s );
+          return 0;
+      }
+      if (packet->size != 8) {
+          stbi_rewind( s );
+          return 0;
+      }
+   } while (chained);
+
+   *comp = (act_comp & 0x10 ? 4 : 3);
+
+   return 1;
+}
+
+static int stbi_info_main(stbi *s, int *x, int *y, int *comp)
+{
+   if (stbi_jpeg_info(s, x, y, comp))
+       return 1;
+   if (stbi_png_info(s, x, y, comp))
+       return 1;
+   if (stbi_gif_info(s, x, y, comp))
+       return 1;
+   if (stbi_bmp_info(s, x, y, comp))
+       return 1;
+   if (stbi_psd_info(s, x, y, comp))
+       return 1;
+   if (stbi_pic_info(s, x, y, comp))
+       return 1;
+   #ifndef STBI_NO_HDR
+   if (stbi_hdr_info(s, x, y, comp))
+       return 1;
+   #endif
+   // test tga last because it's a crappy test!
+   if (stbi_tga_info(s, x, y, comp))
+       return 1;
+   return e("unknown image type", "Image not of any known type, or corrupt");
+}
 
 #ifndef STBI_NO_STDIO
 int stbi_info(char const *filename, int *x, int *y, int *comp)
@@ -4840,49 +4559,50 @@ int stbi_info(char const *filename, int *x, int *y, int *comp)
 
 int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
 {
-   if (stbi_jpeg_info_from_file(f, x, y, comp))
-       return 1;
-   if (stbi_png_info_from_file(f, x, y, comp))
-       return 1;
-   if (stbi_gif_info_from_file(f, x, y, comp))
-       return 1;
-   // @TODO: stbi_bmp_info_from_file
-   // @TODO: stbi_psd_info_from_file
-   #ifndef STBI_NO_HDR
-   // @TODO: stbi_hdr_info_from_file
-   #endif
-   // test tga last because it's a crappy test!
-   if (stbi_tga_info_from_file(f, x, y, comp))
-       return 1;
-   return e("unknown image type", "Image not of any known type, or corrupt");
+   int r;
+   stbi s;
+   long pos = ftell(f);
+   start_file(&s, f);
+   r = stbi_info_main(&s,x,y,comp);
+   fseek(f,pos,SEEK_SET);
+   return r;
 }
 #endif // !STBI_NO_STDIO
 
 int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
 {
-   if (stbi_jpeg_info_from_memory(buffer, len, x, y, comp))
-       return 1;
-   if (stbi_png_info_from_memory(buffer, len, x, y, comp))
-       return 1;
-   if (stbi_gif_info_from_memory(buffer, len, x, y, comp))
-       return 1;
-   // @TODO: stbi_bmp_info_from_memory
-   // @TODO: stbi_psd_info_from_memory
-   #ifndef STBI_NO_HDR
-   // @TODO: stbi_hdr_info_from_memory
-   #endif
-   // test tga last because it's a crappy test!
-   if (stbi_tga_info_from_memory(buffer, len, x, y, comp))
-       return 1;
-   return e("unknown image type", "Image not of any known type, or corrupt");
+   stbi s;
+   start_mem(&s,buffer,len);
+   return stbi_info_main(&s,x,y,comp);
+}
+
+int stbi_info_from_callbacks(stbi_io_callbacks const *c, void *user, int *x, int *y, int *comp)
+{
+   stbi s;
+   start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi_info_main(&s,x,y,comp);
 }
 
 #endif // STBI_HEADER_FILE_ONLY
 
 /*
    revision history:
-      1.29 (2010-08-16) various warning fixes from Aurelien Pocheville 
-      1.28 (2010-08-01) fix bug in GIF palette transparency (SpartanJ)
+      1.33 (2011-07-14)
+             make stbi_is_hdr work in STBI_NO_HDR (as specified), minor compiler-friendly improvements
+      1.32 (2011-07-13)
+             support for "info" function for all supported filetypes (SpartanJ)
+      1.31 (2011-06-20)
+             a few more leak fixes, bug in PNG handling (SpartanJ)
+      1.30 (2011-06-11)
+             added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
+             removed deprecated format-specific test/load functions
+             removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
+             error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)
+             fix inefficiency in decoding 32-bit BMP (David Woo)
+      1.29 (2010-08-16)
+             various warning fixes from Aurelien Pocheville 
+      1.28 (2010-08-01)
+             fix bug in GIF palette transparency (SpartanJ)
       1.27 (2010-08-01)
              cast-to-uint8 to fix warnings
       1.26 (2010-07-24)
@@ -4896,7 +4616,6 @@ int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *c
              attempt to fix trans_data warning (Won Chun)
       1.23   fixed bug in iPhone support
       1.22 (2010-07-10)
-             removed image *writing* support
              removed image *writing* support
              stbi_info support from Jetro Lauha
              GIF support from Jean-Marc Lienher
@@ -4942,8 +4661,7 @@ int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *c
       0.60   fix compiling as c++
       0.59   fix warnings: merge Dave Moore's -Wall fixes
       0.58   fix bug: zlib uncompressed mode len/nlen was wrong endian
-      0.57   fix bug: jpg last huffman symbol before marker was >9 bits but less
-                      than 16 available
+      0.57   fix bug: jpg last huffman symbol before marker was >9 bits but less than 16 available
       0.56   fix bug: zlib uncompressed mode len vs. nlen
       0.55   fix bug: restart_interval not initialized to 0
       0.54   allow NULL for 'int *comp'
@@ -4951,4 +4669,5 @@ int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *c
       0.52   png handles req_comp=3,4 directly; minor cleanup; jpeg comments
       0.51   obey req_comp requests, 1-component jpegs return as 1-component,
              on 'test' only check type, not whether we support this variant
+      0.50   first released version
 */

--- a/Libraries/stb/stb_truetype.h
+++ b/Libraries/stb/stb_truetype.h
@@ -1,4 +1,4 @@
-// stb_truetype.h - v0.3 - public domain - 2009 Sean Barrett / RAD Game Tools
+// stb_truetype.h - v0.6 - public domain - 2009 Sean Barrett / RAD Game Tools
 //
 //   This library processes TrueType files:
 //        parse files
@@ -9,16 +9,39 @@
 //   Todo:
 //        non-MS cmaps
 //        crashproof on bad data
-//        hinting
-//        subpixel positioning when rendering bitmap
-//        cleartype-style AA
+//        hinting? (no longer patented)
+//        cleartype-style AA?
+//        optimize: use simple memory allocator for intermediates
+//        optimize: build edge-list directly from curves
+//        optimize: rasterize directly from curves?
 //
 // ADDITIONAL CONTRIBUTORS
 //
 //   Mikko Mononen: compound shape support, more cmap formats
+//   Tor Andersson: kerning, subpixel rendering
 //
-// VERSIONS
+//   Bug/warning reports:
+//       "Zer" on mollyrocket (with fix)
+//       Cass Everitt
+//       stoiko (Haemimont Games)
+//       Brian Hook 
+//       Walter van Niftrik
 //
+// VERSION HISTORY
+//
+//   0.6 (2012-07-17) fix warnings; added stbtt_ScaleForMappingEmToPixels,
+//                        stbtt_GetFontBoundingBox, stbtt_IsGlyphEmpty
+//   0.5 (2011-12-09) bugfixes:
+//                        subpixel glyph renderer computed wrong bounding box
+//                        first vertex of shape can be off-curve (FreeSans)
+//   0.4b(2011-12-03) fixed an error in the font baking example
+//   0.4 (2011-12-01) kerning, subpixel rendering (tor)
+//                    bugfixes for:
+//                        codepoint-to-glyph conversion using table fmt=12
+//                        codepoint-to-glyph conversion using table fmt=4
+//                        stbtt_GetBakedQuad with non-square texture (Zer)
+//                    updated Hello World! sample to use kerning and subpixel
+//                    fixed some warnings
 //   0.3 (2009-06-24) cmap fmt=12, compound shapes (MM)
 //                    userdata, malloc-from-userdata, non-zero fill (STB)
 //   0.2 (2009-03-11) Fix unsigned/signed char warnings
@@ -51,6 +74,28 @@
 //   Character advance/positioning
 //           stbtt_GetCodepointHMetrics()
 //           stbtt_GetFontVMetrics()
+//           stbtt_GetCodepointKernAdvance()
+//
+// ADVANCED USAGE
+//
+//   Quality:
+//
+//    - Use the functions with Subpixel at the end to allow your characters
+//      to have subpixel positioning. Since the font is anti-aliased, not
+//      hinted, this is very import for quality.
+//
+//    - Kerning is now supported, and if you're supporting subpixel rendering
+//      then kerning is worth using to give your text a polished look.
+//
+//   Performance:
+//
+//    - Convert Unicode codepoints to "glyphs" and operate on the glyphs; if
+//      you don't do this, stb_truetype is forced to do the conversion on
+//      every call.
+//
+//    - There are a lot of memory allocations. We should modify it to take
+//      a temp buffer and allocate from the temp buffer (without freeing),
+//      should help performance a lot.
 //
 // NOTES
 //
@@ -64,14 +109,14 @@
 //   recommend it.
 //
 //
-// SOURCE STATISTICS (based on v0.3, 1800 LOC)
+// SOURCE STATISTICS (based on v0.5, 1980 LOC)
 //
-//   Documentation & header file        350 LOC  \___ 500 LOC documentation
+//   Documentation & header file        450 LOC  \___ 550 LOC documentation
 //   Sample code                        140 LOC  /
-//   Truetype parsing                   580 LOC  ---- 600 LOC TrueType
+//   Truetype parsing                   590 LOC  ---- 600 LOC TrueType
 //   Software rasterization             240 LOC  \                           .
-//   Curve tesselation                  120 LOC   \__ 500 LOC Bitmap creation
-//   Bitmap management                   70 LOC   /
+//   Curve tesselation                  120 LOC   \__ 550 LOC Bitmap creation
+//   Bitmap management                  100 LOC   /
 //   Baked bitmap interface              70 LOC  /
 //   Font name matching & access        150 LOC  ---- 150 
 //   C runtime library abstraction       60 LOC  ----  60
@@ -92,7 +137,7 @@
 char ttf_buffer[1<<20];
 unsigned char temp_bitmap[512*512];
 
-stbtt_chardata cdata[96]; // ASCII 32..126 is 95 glyphs
+stbtt_bakedchar cdata[96]; // ASCII 32..126 is 95 glyphs
 GLstbtt_uint ftex;
 
 void my_stbtt_initfont(void)
@@ -177,33 +222,40 @@ int main(int argc, char **argv)
 // Complete program: print "Hello World!" banner, with bugs
 //
 #if 0
+char buffer[24<<20];
+unsigned char screen[20][79];
+
 int main(int arg, char **argv)
 {
-   unsigned char screen[20][79];
-   int i,j, pos=0;
-   float scale;
+   stbtt_fontinfo font;
+   int i,j,ascent,baseline,ch=0;
+   float scale, xpos=0;
    char *text = "Heljo World!";
 
    fread(buffer, 1, 1000000, fopen("c:/windows/fonts/arialbd.ttf", "rb"));
    stbtt_InitFont(&font, buffer, 0);
 
-   scale = stbtt_ScaleForPixelHeight(&font, 16);
-   memset(screen, 0, sizeof(screen));
+   scale = stbtt_ScaleForPixelHeight(&font, 15);
+   stbtt_GetFontVMetrics(&font, &ascent,0,0);
+   baseline = (int) (ascent*scale);
 
-   while (*text) {
-      int advance,lsb,x0,y0,x1,y1, newpos, baseline=13;
-      stbtt_GetCodepointHMetrics(&font, *text, &advance, &lsb);
-      stbtt_GetCodepointBitmapBox(&font, *text, scale,scale, &x0,&y0,&x1,&y1);
-      newpos = pos + (int) (lsb * scale) + x0;
-      stbtt_MakeCodepointBitmap(&font, &screen[baseline + y0][newpos], x1-x0,y1-y0, 79, scale,scale, *text);
+   while (text[ch]) {
+      int advance,lsb,x0,y0,x1,y1;
+      float x_shift = xpos - (float) floor(xpos);
+      stbtt_GetCodepointHMetrics(&font, text[ch], &advance, &lsb);
+      stbtt_GetCodepointBitmapBoxSubpixel(&font, text[ch], scale,scale,x_shift,0, &x0,&y0,&x1,&y1);
+      stbtt_MakeCodepointBitmapSubpixel(&font, &screen[baseline + y0][(int) xpos + x0], x1-x0,y1-y0, 79, scale,scale,x_shift,0, text[ch]);
       // note that this stomps the old data, so where character boxes overlap (e.g. 'lj') it's wrong
-      // because this API is really for baking character bitmaps into textures
-      pos += (int) (advance * scale);
-      ++text;
+      // because this API is really for baking character bitmaps into textures. if you want to do this,
+      // you need to render the bitmap to a temp buffer, then "alpha blend" that into the working buffer
+      xpos += (advance * scale);
+      if (text[ch+1])
+         xpos += scale*stbtt_GetCodepointKernAdvance(&font, text[ch],text[ch+1]);
+      ++ch;
    }
 
    for (j=0; j < 20; ++j) {
-      for (i=0; i < 79; ++i)
+      for (i=0; i < 78; ++i)
          putchar(" .:ioVM@"[screen[j][i]>>5]);
       putchar('\n');
    }
@@ -340,17 +392,17 @@ extern int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index);
 
 // The following structure is defined publically so you can declare one on
 // the stack or as a global or etc.
-typedef struct
+typedef struct stbtt_fontinfo
 {
-   void           *userdata;
-   unsigned char  *data;         // pointer to .ttf file
-   int             fontstart;    // offset of start of font
+   void           * userdata;
+   unsigned char  * data;              // pointer to .ttf file
+   int              fontstart;         // offset of start of font
 
-   int numGlyphs;                // number of glyphs, needed for range checking
+   int numGlyphs;                     // number of glyphs, needed for range checking
 
-   int loca,head,glyf,hhea,hmtx; // table locations as offset from start of .ttf
-   int index_map;                // a cmap mapping for our chosen character encoding
-   int indexToLocFormat;         // format needed to map from glyph index to glyph
+   int loca,head,glyf,hhea,hmtx,kern; // table locations as offset from start of .ttf
+   int index_map;                     // a cmap mapping for our chosen character encoding
+   int indexToLocFormat;              // format needed to map from glyph index to glyph
 } stbtt_fontinfo;
 
 extern int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset);
@@ -385,12 +437,20 @@ extern float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float pixels)
 //       scale = pixels / (ascent - descent)
 // so if you prefer to measure height by the ascent only, use a similar calculation.
 
+extern float stbtt_ScaleForMappingEmToPixels(const stbtt_fontinfo *info, float pixels);
+// computes a scale factor to produce a font whose EM size is mapped to
+// 'pixels' tall. This is probably what traditional APIs compute, but
+// I'm not positive.
+
 extern void stbtt_GetFontVMetrics(const stbtt_fontinfo *info, int *ascent, int *descent, int *lineGap);
 // ascent is the coordinate above the baseline the font extends; descent
 // is the coordinate below the baseline the font extends (i.e. it is typically negative)
 // lineGap is the spacing between one row's descent and the next row's ascent...
 // so you should advance the vertical position by "*ascent - *descent + *lineGap"
 //   these are expressed in unscaled coordinates
+
+extern void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info, int *x0, int *y0, int *x1, int *y1);
+// the bounding box around all possible characters
 
 extern void stbtt_GetCodepointHMetrics(const stbtt_fontinfo *info, int codepoint, int *advanceWidth, int *leftSideBearing);
 // leftSideBearing is the offset from the current horizontal position to the left edge of the character
@@ -434,6 +494,9 @@ extern int  stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, int *
    } stbtt_vertex;
 #endif
 
+extern int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index);
+// returns non-zero if nothing is drawn for this glyph
+
 extern int stbtt_GetCodepointShape(const stbtt_fontinfo *info, int unicode_codepoint, stbtt_vertex **vertices);
 extern int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **vertices);
 // returns # of vertices and fills *vertices with the pointer to them
@@ -459,11 +522,19 @@ extern unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info, float
 //
 // xoff/yoff are the offset it pixel space from the glyph origin to the top-left of the bitmap
 
+extern unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint, int *width, int *height, int *xoff, int *yoff);
+// the same as stbtt_GetCodepoitnBitmap, but you can specify a subpixel
+// shift for the character
+
 extern void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int codepoint);
-// the same as above, but you pass in storage for the bitmap in the form
-// of 'output', with row spacing of 'out_stride' bytes. the bitmap is
-// clipped to out_w/out_h bytes. call the next function to get the
-// height and width and positioning info
+// the same as stbtt_GetCodepointBitmap, but you pass in storage for the bitmap
+// in the form of 'output', with row spacing of 'out_stride' bytes. the bitmap
+// is clipped to out_w/out_h bytes. Call stbtt_GetCodepointBitmapBox to get the
+// width and height and positioning info for it first.
+
+extern void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint);
+// same as stbtt_MakeCodepointBitmap, but you can specify a subpixel
+// shift for the character
 
 extern void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
 // get the bbox of the bitmap centered around the glyph origin; so the
@@ -472,11 +543,19 @@ extern void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codepoin
 // (Note that the bitmap uses y-increases-down, but the shape uses
 // y-increases-up, so CodepointBitmapBox and CodepointBox are inverted.)
 
-extern unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff);
-extern void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
-extern void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph);
+extern void stbtt_GetCodepointBitmapBoxSubpixel(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1);
+// same as stbtt_GetCodepointBitmapBox, but you can specify a subpixel
+// shift for the character
 
-//extern void stbtt_get_true_bbox(stbtt_vertex *vertices, int num_verts, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
+// the following functions are equivalent to the above functions, but operate
+// on glyph indices instead of Unicode codepoints (for efficiency)
+extern unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff);
+extern unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int glyph, int *width, int *height, int *xoff, int *yoff);
+extern void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph);
+extern void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int glyph);
+extern void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
+extern void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y,float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1);
+
 
 // @TODO: don't expose this structure
 typedef struct
@@ -485,7 +564,7 @@ typedef struct
    unsigned char *pixels;
 } stbtt__bitmap;
 
-extern void stbtt_Rasterize(stbtt__bitmap *result, float flatness_in_pixels, stbtt_vertex *vertices, int num_verts, float scale_x, float scale_y, int x_off, int y_off, int invert, void *userdata);
+extern void stbtt_Rasterize(stbtt__bitmap *result, float flatness_in_pixels, stbtt_vertex *vertices, int num_verts, float scale_x, float scale_y, float shift_x, float shift_y, int x_off, int y_off, int invert, void *userdata);
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -524,7 +603,7 @@ extern int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const ch
 // returns 1/0 whether the first string interpreted as utf8 is identical to
 // the second string interpreted as big-endian utf16... useful for strings from next func
 
-extern char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platformID, int encodingID, int languageID, int nameID);
+extern const char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platformID, int encodingID, int languageID, int nameID);
 // returns the string (which may be big-endian double byte, e.g. for unicode)
 // and puts the length in bytes in *length.
 //
@@ -544,21 +623,21 @@ enum { // encodingID for STBTT_PLATFORM_ID_UNICODE
    STBTT_UNICODE_EID_UNICODE_1_1    =1,
    STBTT_UNICODE_EID_ISO_10646      =2,
    STBTT_UNICODE_EID_UNICODE_2_0_BMP=3,
-   STBTT_UNICODE_EID_UNICODE_2_0_FULL=4,
+   STBTT_UNICODE_EID_UNICODE_2_0_FULL=4
 };
 
 enum { // encodingID for STBTT_PLATFORM_ID_MICROSOFT
    STBTT_MS_EID_SYMBOL        =0,
    STBTT_MS_EID_UNICODE_BMP   =1,
    STBTT_MS_EID_SHIFTJIS      =2,
-   STBTT_MS_EID_UNICODE_FULL  =10,
+   STBTT_MS_EID_UNICODE_FULL  =10
 };
 
 enum { // encodingID for STBTT_PLATFORM_ID_MAC; same as Script Manager codes
    STBTT_MAC_EID_ROMAN        =0,   STBTT_MAC_EID_ARABIC       =4,
    STBTT_MAC_EID_JAPANESE     =1,   STBTT_MAC_EID_HEBREW       =5,
    STBTT_MAC_EID_CHINESE_TRAD =2,   STBTT_MAC_EID_GREEK        =6,
-   STBTT_MAC_EID_KOREAN       =3,   STBTT_MAC_EID_RUSSIAN      =7,
+   STBTT_MAC_EID_KOREAN       =3,   STBTT_MAC_EID_RUSSIAN      =7
 };
 
 enum { // languageID for STBTT_PLATFORM_ID_MICROSOFT; same as LCID...
@@ -568,7 +647,7 @@ enum { // languageID for STBTT_PLATFORM_ID_MICROSOFT; same as LCID...
    STBTT_MS_LANG_DUTCH       =0x0413,   STBTT_MS_LANG_KOREAN      =0x0412,
    STBTT_MS_LANG_FRENCH      =0x040c,   STBTT_MS_LANG_RUSSIAN     =0x0419,
    STBTT_MS_LANG_GERMAN      =0x0407,   STBTT_MS_LANG_SPANISH     =0x0409,
-   STBTT_MS_LANG_HEBREW      =0x040d,   STBTT_MS_LANG_SWEDISH     =0x041D,
+   STBTT_MS_LANG_HEBREW      =0x040d,   STBTT_MS_LANG_SWEDISH     =0x041D
 };
 
 enum { // languageID for STBTT_PLATFORM_ID_MAC
@@ -578,7 +657,7 @@ enum { // languageID for STBTT_PLATFORM_ID_MAC
    STBTT_MAC_LANG_FRENCH       =1 ,   STBTT_MAC_LANG_SPANISH      =6 ,
    STBTT_MAC_LANG_GERMAN       =2 ,   STBTT_MAC_LANG_SWEDISH      =5 ,
    STBTT_MAC_LANG_HEBREW       =10,   STBTT_MAC_LANG_CHINESE_SIMPLIFIED =33,
-   STBTT_MAC_LANG_ITALIAN      =3 ,   STBTT_MAC_LANG_CHINESE_TRAD =19,
+   STBTT_MAC_LANG_ITALIAN      =3 ,   STBTT_MAC_LANG_CHINESE_TRAD =19
 };
 
 #ifdef __cplusplus
@@ -630,7 +709,7 @@ enum { // languageID for STBTT_PLATFORM_ID_MAC
 static int stbtt__isfont(const stbtt_uint8 *font)
 {
    // check the version number
-   if (stbtt_tag(font, "1"))   return 1; // TrueType 1
+   if (stbtt_tag4(font, '1',0,0,0))  return 1; // TrueType 1
    if (stbtt_tag(font, "typ1"))   return 1; // TrueType with type 1 font -- we don't support this!
    if (stbtt_tag(font, "OTTO"))   return 1; // OpenType with CFF
    if (stbtt_tag4(font, 0,1,0,0)) return 1; // OpenType 1.0
@@ -638,7 +717,7 @@ static int stbtt__isfont(const stbtt_uint8 *font)
 }
 
 // @OPTIMIZE: binary search
-static stbtt_uint32 stbtt__find_table(stbtt_uint8 *data, stbtt_uint32 fontstart, char *tag)
+static stbtt_uint32 stbtt__find_table(stbtt_uint8 *data, stbtt_uint32 fontstart, const char *tag)
 {
    stbtt_int32 num_tables = ttUSHORT(data+fontstart+4);
    stbtt_uint32 tabledir = fontstart + 12;
@@ -679,12 +758,13 @@ int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data2, int fontsta
    info->data = data;
    info->fontstart = fontstart;
 
-   cmap = stbtt__find_table(data, fontstart, "cmap");
-   info->loca = stbtt__find_table(data, fontstart, "loca");
-   info->head = stbtt__find_table(data, fontstart, "head");
-   info->glyf = stbtt__find_table(data, fontstart, "glyf");
-   info->hhea = stbtt__find_table(data, fontstart, "hhea");
-   info->hmtx = stbtt__find_table(data, fontstart, "hmtx");
+   cmap = stbtt__find_table(data, fontstart, "cmap");       // required
+   info->loca = stbtt__find_table(data, fontstart, "loca"); // required
+   info->head = stbtt__find_table(data, fontstart, "head"); // required
+   info->glyf = stbtt__find_table(data, fontstart, "glyf"); // required
+   info->hhea = stbtt__find_table(data, fontstart, "hhea"); // required
+   info->hmtx = stbtt__find_table(data, fontstart, "hmtx"); // required
+   info->kern = stbtt__find_table(data, fontstart, "kern"); // not required
    if (!cmap || !info->loca || !info->head || !info->glyf || !info->hhea || !info->hmtx)
       return 0;
 
@@ -785,26 +865,29 @@ int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codepoint)
 
       offset = ttUSHORT(data + index_map + 14 + segcount*6 + 2 + 2*item);
       if (offset == 0)
-         return unicode_codepoint + ttSHORT(data + index_map + 14 + segcount*4 + 2 + 2*item);
+         return (stbtt_uint16) (unicode_codepoint + ttSHORT(data + index_map + 14 + segcount*4 + 2 + 2*item));
 
       return ttUSHORT(data + offset + (unicode_codepoint-start)*2 + index_map + 14 + segcount*6 + 2 + 2*item);
-   } else if (format == 12) {
-      stbtt_uint16 ngroups = ttUSHORT(data+index_map+6);
+   } else if (format == 12 || format == 13) {
+      stbtt_uint32 ngroups = ttULONG(data+index_map+12);
       stbtt_int32 low,high;
       stbtt_uint16 g = 0;
       low = 0; high = (stbtt_int32)ngroups;
       // Binary search the right group.
-      while (low <= high) {
+      while (low < high) {
          stbtt_int32 mid = low + ((high-low) >> 1); // rounds down, so low <= mid < high
          stbtt_uint32 start_char = ttULONG(data+index_map+16+mid*12);
          stbtt_uint32 end_char = ttULONG(data+index_map+16+mid*12+4);
          if ((stbtt_uint32) unicode_codepoint < start_char)
-            high = mid-1;
+            high = mid;
          else if ((stbtt_uint32) unicode_codepoint > end_char)
             low = mid+1;
          else {
             stbtt_uint32 start_glyph = ttULONG(data+index_map+16+mid*12+8);
-            return start_glyph + unicode_codepoint-start_char;
+            if (format == 12)
+               return start_glyph + unicode_codepoint-start_char;
+            else // format == 13
+               return start_glyph;
          }
       }
       return 0; // not found
@@ -819,13 +902,13 @@ int stbtt_GetCodepointShape(const stbtt_fontinfo *info, int unicode_codepoint, s
    return stbtt_GetGlyphShape(info, stbtt_FindGlyphIndex(info, unicode_codepoint), vertices);
 }
 
-static void stbtt_setvertex(stbtt_vertex *v, stbtt_uint8 type, stbtt_int16 x, stbtt_int16 y, stbtt_int16 cx, stbtt_int16 cy)
+static void stbtt_setvertex(stbtt_vertex *v, stbtt_uint8 type, stbtt_int32 x, stbtt_int32 y, stbtt_int32 cx, stbtt_int32 cy)
 {
    v->type = type;
-   v->x = x;
-   v->y = y;
-   v->cx = cx;
-   v->cy = cy;
+   v->x = (stbtt_int16) x;
+   v->y = (stbtt_int16) y;
+   v->cx = (stbtt_int16) cx;
+   v->cy = (stbtt_int16) cy;
 }
 
 static int stbtt__GetGlyfOffset(const stbtt_fontinfo *info, int glyph_index)
@@ -863,6 +946,31 @@ int stbtt_GetCodepointBox(const stbtt_fontinfo *info, int codepoint, int *x0, in
    return stbtt_GetGlyphBox(info, stbtt_FindGlyphIndex(info,codepoint), x0,y0,x1,y1);
 }
 
+int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index)
+{
+   stbtt_int16 numberOfContours;
+   int g = stbtt__GetGlyfOffset(info, glyph_index);
+   if (g < 0) return 1;
+   numberOfContours = ttSHORT(info->data + g);
+   return numberOfContours == 0;
+}
+
+static int stbtt__close_shape(stbtt_vertex *vertices, int num_vertices, int was_off, int start_off,
+    stbtt_int32 sx, stbtt_int32 sy, stbtt_int32 scx, stbtt_int32 scy, stbtt_int32 cx, stbtt_int32 cy)
+{
+   if (start_off) {
+      if (was_off)
+         stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, (cx+scx)>>1, (cy+scy)>>1, cx,cy);
+      stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, sx,sy,scx,scy);
+   } else {
+      if (was_off)
+         stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve,sx,sy,cx,cy);
+      else
+         stbtt_setvertex(&vertices[num_vertices++], STBTT_vline,sx,sy,0,0);
+   }
+   return num_vertices;
+}
+
 int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
 {
    stbtt_int16 numberOfContours;
@@ -880,8 +988,8 @@ int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_verte
 
    if (numberOfContours > 0) {
       stbtt_uint8 flags=0,flagcount;
-      stbtt_int32 ins, i,j=0,m,n, next_move, was_off=0, off;
-      stbtt_int16 x,y,cx,cy,sx,sy;
+      stbtt_int32 ins, i,j=0,m,n, next_move, was_off=0, off, start_off=0, curve_end=0;
+      stbtt_int32 x,y,cx,cy,sx,sy, scx,scy;
       stbtt_uint8 *points;
       endPtsOfContours = (data + g + 10);
       ins = ttUSHORT(data + g + 10 + numberOfContours * 2);
@@ -889,7 +997,7 @@ int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_verte
 
       n = 1+ttUSHORT(endPtsOfContours + numberOfContours*2-2);
 
-      m = n + numberOfContours;  // a loose bound on how many vertices we might need
+      m = n + 2*numberOfContours;  // a loose bound on how many vertices we might need
       vertices = (stbtt_vertex *) STBTT_malloc(m * sizeof(vertices[0]), info->userdata);
       if (vertices == 0)
          return 0;
@@ -928,7 +1036,7 @@ int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_verte
                points += 2;
             }
          }
-         vertices[off+i].x = x;
+         vertices[off+i].x = (stbtt_int16) x;
       }
 
       // now load y coordinates
@@ -944,32 +1052,46 @@ int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_verte
                points += 2;
             }
          }
-         vertices[off+i].y = y;
+         vertices[off+i].y = (stbtt_int16) y;
       }
 
       // now convert them to our format
       num_vertices=0;
-      sx = sy = cx = cy = 0;
+      sx = sy = cx = cy = scx = scy = 0;
       for (i=0; i < n; ++i) {
          flags = vertices[off+i].type;
          x     = (stbtt_int16) vertices[off+i].x;
          y     = (stbtt_int16) vertices[off+i].y;
+
          if (next_move == i) {
-            // when we get to the end, we have to close the shape explicitly
-            if (i != 0) {
-               if (was_off)
-                  stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve,sx,sy,cx,cy);
-               else
-                  stbtt_setvertex(&vertices[num_vertices++], STBTT_vline,sx,sy,0,0);
-            }
+            if (i != 0)
+               num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
 
             // now start the new one               
-            stbtt_setvertex(&vertices[num_vertices++], STBTT_vmove,x,y,0,0);
+            start_off = !(flags & 1);
+            if (start_off) {
+               // if we start off with an off-curve point, then when we need to find a point on the curve
+               // where we can start, and we need to save some state for when we wraparound.
+               scx = x;
+               scy = y;
+               if (!(vertices[off+i+1].type & 1)) {
+                  // next point is also a curve point, so interpolate an on-point curve
+                  sx = (x + (stbtt_int32) vertices[off+i+1].x) >> 1;
+                  sy = (y + (stbtt_int32) vertices[off+i+1].y) >> 1;
+               } else {
+                  // otherwise just use the next point as our start point
+                  sx = (stbtt_int32) vertices[off+i+1].x;
+                  sy = (stbtt_int32) vertices[off+i+1].y;
+                  ++i; // we're using point i+1 as the starting point, so skip it
+               }
+            } else {
+               sx = x;
+               sy = y;
+            }
+            stbtt_setvertex(&vertices[num_vertices++], STBTT_vmove,sx,sy,0,0);
+            was_off = 0;
             next_move = 1 + ttUSHORT(endPtsOfContours+j*2);
             ++j;
-            was_off = 0;
-            sx = x;
-            sy = y;
          } else {
             if (!(flags & 1)) { // if it's a curve
                if (was_off) // two off-curve control points in a row means interpolate an on-curve midpoint
@@ -986,12 +1108,7 @@ int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_verte
             }
          }
       }
-      if (i != 0) {
-         if (was_off)
-            stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve,sx,sy,cx,cy);
-         else
-            stbtt_setvertex(&vertices[num_vertices++], STBTT_vline,sx,sy,0,0);
-      }
+      num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
    } else if (numberOfContours == -1) {
       // Compound shapes.
       int more = 1;
@@ -1094,12 +1211,39 @@ void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info, int glyph_index, int *ad
 
 int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
 {
+   stbtt_uint8 *data = info->data + info->kern;
+   stbtt_uint32 needle, straw;
+   int l, r, m;
+
+   // we only look at the first table. it must be 'horizontal' and format 0.
+   if (!info->kern)
+      return 0;
+   if (ttUSHORT(data+2) < 1) // number of tables, need at least 1
+      return 0;
+   if (ttUSHORT(data+8) != 1) // horizontal flag must be set in format
+      return 0;
+
+   l = 0;
+   r = ttUSHORT(data+10) - 1;
+   needle = glyph1 << 16 | glyph2;
+   while (l <= r) {
+      m = (l + r) >> 1;
+      straw = ttULONG(data+18+(m*6)); // note: unaligned read
+      if (needle < straw)
+         r = m - 1;
+      else if (needle > straw)
+         l = m + 1;
+      else
+         return ttSHORT(data+22+(m*6));
+   }
    return 0;
 }
 
 int  stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2)
 {
-   return 0;
+   if (!info->kern) // if no kerning table, don't waste time looking up both codepoint->glyphs
+      return 0;
+   return stbtt_GetGlyphKernAdvance(info, stbtt_FindGlyphIndex(info,ch1), stbtt_FindGlyphIndex(info,ch2));
 }
 
 void stbtt_GetCodepointHMetrics(const stbtt_fontinfo *info, int codepoint, int *advanceWidth, int *leftSideBearing)
@@ -1114,10 +1258,24 @@ void stbtt_GetFontVMetrics(const stbtt_fontinfo *info, int *ascent, int *descent
    if (lineGap) *lineGap = ttSHORT(info->data+info->hhea + 8);
 }
 
+void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info, int *x0, int *y0, int *x1, int *y1)
+{
+   *x0 = ttSHORT(info->data + info->head + 36);
+   *y0 = ttSHORT(info->data + info->head + 38);
+   *x1 = ttSHORT(info->data + info->head + 40);
+   *y1 = ttSHORT(info->data + info->head + 42);
+}
+
 float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float height)
 {
    int fheight = ttSHORT(info->data + info->hhea + 4) - ttSHORT(info->data + info->hhea + 6);
    return (float) height / fheight;
+}
+
+float stbtt_ScaleForMappingEmToPixels(const stbtt_fontinfo *info, float pixels)
+{
+   int unitsPerEm = ttUSHORT(info->data + info->head + 18);
+   return pixels / unitsPerEm;
 }
 
 void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *v)
@@ -1130,21 +1288,30 @@ void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *v)
 // antialiasing software rasterizer
 //
 
-void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1)
+void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y,float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1)
 {
    int x0,y0,x1,y1;
    if (!stbtt_GetGlyphBox(font, glyph, &x0,&y0,&x1,&y1))
       x0=y0=x1=y1=0; // e.g. space character
    // now move to integral bboxes (treating pixels as little squares, what pixels get touched)?
-   if (ix0) *ix0 =  STBTT_ifloor(x0 * scale_x);
-   if (iy0) *iy0 = -STBTT_iceil (y1 * scale_y);
-   if (ix1) *ix1 =  STBTT_iceil (x1 * scale_x);
-   if (iy1) *iy1 = -STBTT_ifloor(y0 * scale_y);
+   if (ix0) *ix0 =  STBTT_ifloor(x0 * scale_x + shift_x);
+   if (iy0) *iy0 = -STBTT_iceil (y1 * scale_y + shift_y);
+   if (ix1) *ix1 =  STBTT_iceil (x1 * scale_x + shift_x);
+   if (iy1) *iy1 = -STBTT_ifloor(y0 * scale_y + shift_y);
+}
+void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1)
+{
+   stbtt_GetGlyphBitmapBoxSubpixel(font, glyph, scale_x, scale_y,0.0f,0.0f, ix0, iy0, ix1, iy1);
+}
+
+void stbtt_GetCodepointBitmapBoxSubpixel(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1)
+{
+   stbtt_GetGlyphBitmapBoxSubpixel(font, stbtt_FindGlyphIndex(font,codepoint), scale_x, scale_y,shift_x,shift_y, ix0,iy0,ix1,iy1);
 }
 
 void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1)
 {
-   stbtt_GetGlyphBitmapBox(font, stbtt_FindGlyphIndex(font,codepoint), scale_x, scale_y, ix0,iy0,ix1,iy1);
+   stbtt_GetCodepointBitmapBoxSubpixel(font, codepoint, scale_x, scale_y,0.0f,0.0f, ix0,iy0,ix1,iy1);
 }
 
 typedef struct stbtt__edge {
@@ -1344,7 +1511,7 @@ typedef struct
    float x,y;
 } stbtt__point;
 
-static void stbtt__rasterize(stbtt__bitmap *result, stbtt__point *pts, int *wcount, int windings, float scale_x, float scale_y, int off_x, int off_y, int invert, void *userdata)
+static void stbtt__rasterize(stbtt__bitmap *result, stbtt__point *pts, int *wcount, int windings, float scale_x, float scale_y, float shift_x, float shift_y, int off_x, int off_y, int invert, void *userdata)
 {
    float y_scale_inv = invert ? -scale_y : scale_y;
    stbtt__edge *e;
@@ -1377,10 +1544,10 @@ static void stbtt__rasterize(stbtt__bitmap *result, stbtt__point *pts, int *wcou
             e[n].invert = 1;
             a=j,b=k;
          }
-         e[n].x0 = p[a].x * scale_x;
-         e[n].y0 = p[a].y * y_scale_inv * vsubsample;
-         e[n].x1 = p[b].x * scale_x;
-         e[n].y1 = p[b].y * y_scale_inv * vsubsample;
+         e[n].x0 = p[a].x * scale_x + shift_x;
+         e[n].y0 = p[a].y * y_scale_inv * vsubsample + shift_y;
+         e[n].x1 = p[b].x * scale_x + shift_x;
+         e[n].y1 = p[b].y * y_scale_inv * vsubsample + shift_y;
          ++n;
       }
    }
@@ -1492,13 +1659,13 @@ error:
    return NULL;
 }
 
-void stbtt_Rasterize(stbtt__bitmap *result, float flatness_in_pixels, stbtt_vertex *vertices, int num_verts, float scale_x, float scale_y, int x_off, int y_off, int invert, void *userdata)
+void stbtt_Rasterize(stbtt__bitmap *result, float flatness_in_pixels, stbtt_vertex *vertices, int num_verts, float scale_x, float scale_y, float shift_x, float shift_y, int x_off, int y_off, int invert, void *userdata)
 {
    float scale = scale_x > scale_y ? scale_y : scale_x;
    int winding_count, *winding_lengths;
    stbtt__point *windings = stbtt_FlattenCurves(vertices, num_verts, flatness_in_pixels / scale, &winding_lengths, &winding_count, userdata);
    if (windings) {
-      stbtt__rasterize(result, windings, winding_lengths, winding_count, scale_x, scale_y, x_off, y_off, invert, userdata);
+      stbtt__rasterize(result, windings, winding_lengths, winding_count, scale_x, scale_y, shift_x, shift_y, x_off, y_off, invert, userdata);
       STBTT_free(winding_lengths, userdata);
       STBTT_free(windings, userdata);
    }
@@ -1509,7 +1676,7 @@ void stbtt_FreeBitmap(unsigned char *bitmap, void *userdata)
    STBTT_free(bitmap, userdata);
 }
 
-unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff)
+unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int glyph, int *width, int *height, int *xoff, int *yoff)
 {
    int ix0,iy0,ix1,iy1;
    stbtt__bitmap gbm;
@@ -1539,47 +1706,67 @@ unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, f
       if (gbm.pixels) {
          gbm.stride = gbm.w;
 
-         stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, ix0, iy0, 1, info->userdata);
+         stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, ix0, iy0, 1, info->userdata);
       }
    }
    STBTT_free(vertices, info->userdata);
    return gbm.pixels;
 }   
 
-void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph)
+unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff)
+{
+   return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y, 0.0f, 0.0f, glyph, width, height, xoff, yoff);
+}
+
+void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int glyph)
 {
    int ix0,iy0;
-   stbtt_vertex *vertices;   
+   stbtt_vertex *vertices;
    int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
    stbtt__bitmap gbm;   
 
-   stbtt_GetGlyphBitmapBox(info, glyph, scale_x, scale_y, &ix0,&iy0,0,0);
+   stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0,&iy0,0,0);
    gbm.pixels = output;
    gbm.w = out_w;
    gbm.h = out_h;
    gbm.stride = out_stride;
 
    if (gbm.w && gbm.h)
-      stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, ix0,iy0, 1, info->userdata);
+      stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, ix0,iy0, 1, info->userdata);
 
    STBTT_free(vertices, info->userdata);
 }
 
+void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph)
+{
+   stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, 0.0f,0.0f, glyph);
+}
+
+unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint, int *width, int *height, int *xoff, int *yoff)
+{
+   return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y,shift_x,shift_y, stbtt_FindGlyphIndex(info,codepoint), width,height,xoff,yoff);
+}   
+
+void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint)
+{
+   stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, stbtt_FindGlyphIndex(info,codepoint));
+}
+
 unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int codepoint, int *width, int *height, int *xoff, int *yoff)
 {
-   return stbtt_GetGlyphBitmap(info, scale_x, scale_y, stbtt_FindGlyphIndex(info,codepoint), width,height,xoff,yoff);
+   return stbtt_GetCodepointBitmapSubpixel(info, scale_x, scale_y, 0.0f,0.0f, codepoint, width,height,xoff,yoff);
 }   
 
 void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int codepoint)
 {
-   stbtt_MakeGlyphBitmap(info, output, out_w, out_h, out_stride, scale_x, scale_y, stbtt_FindGlyphIndex(info,codepoint));
+   stbtt_MakeCodepointBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, 0.0f,0.0f, codepoint);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 //
 // bitmap baking
 //
-// This is SUPER-SHITTY packing to keep source code small
+// This is SUPER-CRAPPY packing to keep source code small
 
 extern int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // font location (use offset=0 for plain .ttf)
                                 float pixel_height,                     // height of font in pixels
@@ -1639,8 +1826,8 @@ void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph, int char_inde
    q->y1 = round_y + b->y1 - b->y0 + d3d_bias;
 
    q->s0 = b->x0 * ipw;
-   q->t0 = b->y0 * ipw;
-   q->s1 = b->x1 * iph;
+   q->t0 = b->y0 * iph;
+   q->s1 = b->x1 * ipw;
    q->t1 = b->y1 * iph;
 
    *xpos += b->xadvance;
@@ -1652,7 +1839,7 @@ void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph, int char_inde
 //
 
 // check if a utf8 string contains a prefix which is the utf16 string; if so return length of matching utf8 string
-static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(stbtt_uint8 *s1, stbtt_int32 len1, stbtt_uint8 *s2, stbtt_int32 len2) 
+static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(const stbtt_uint8 *s1, stbtt_int32 len1, const stbtt_uint8 *s2, stbtt_int32 len2) 
 {
    stbtt_int32 i=0;
 
@@ -1693,12 +1880,12 @@ static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(stbtt_uint8 *s1, s
 
 int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2) 
 {
-   return len1 == stbtt__CompareUTF8toUTF16_bigendian_prefix((stbtt_uint8*) s1, len1, (stbtt_uint8*) s2, len2);
+   return len1 == stbtt__CompareUTF8toUTF16_bigendian_prefix((const stbtt_uint8*) s1, len1, (const stbtt_uint8*) s2, len2);
 }
 
 // returns results in whatever encoding you request... but note that 2-byte encodings
 // will be BIG-ENDIAN... use stbtt_CompareUTF8toUTF16_bigendian() to compare
-char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platformID, int encodingID, int languageID, int nameID)
+const char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platformID, int encodingID, int languageID, int nameID)
 {
    stbtt_int32 i,count,stringOffset;
    stbtt_uint8 *fc = font->data;
@@ -1713,7 +1900,7 @@ char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platf
       if (platformID == ttUSHORT(fc+loc+0) && encodingID == ttUSHORT(fc+loc+2)
           && languageID == ttUSHORT(fc+loc+4) && nameID == ttUSHORT(fc+loc+6)) {
          *length = ttUSHORT(fc+loc+8);
-         return (char *) (fc+stringOffset+ttUSHORT(fc+loc+10));
+         return (const char *) (fc+stringOffset+ttUSHORT(fc+loc+10));
       }
    }
    return NULL;


### PR DESCRIPTION
Almost all the changes are summarized in issue #112, plus updating the stb_truetype.h and stb_image.c files to the newest versions, which fixed many other compilation errors. This has only been tested on OSX (both 32-bit 10.6 and 64-bit 10.7) Comments much appreciated, as I am new to C++!
